### PR TITLE
Allow all origins for CORS

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,7 +23,7 @@ app = Flask(__name__)
 # set environment variable
 app.config["ENV"] = Config.DEPLOY_ENV
 
-cors = CORS(app, resources={r"*": {"origins": Config.SPARC_APP_HOST}})
+CORS(app)
 
 ma = Marshmallow(app)
 email_sender = EmailSender()


### PR DESCRIPTION
# Description

When running the SPARC Portal locally, CORS did not allow requests from `localhost` because it was seen as a foreign origin. This PR changes the CORS header to allow all origins. This should only affect running the portal in a local environment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

~~Since we have to test this from a different origin, we can't run this locally and make a request locally because it will be from the same origin. I believe the best way to test this is to merge it and test it from staging. Any other ideas?~~

1. Run the sparc api locally.
2. Call the api with an explicit origin: `curl http://localhost:3000/health -H "Origin: google.com"`
3. Response will return without CORS issues.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
