### PR TITLE
Restrict file downloads from s3 bucket

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -129,6 +129,7 @@ def create_presigned_url(expiration=3600):
 
     return response
 
+
 # Reverse proxy for objects from S3, a simple get object
 # operation. This is used by scaffoldvuer and its 
 # important to keep the relative <path> for accessing
@@ -143,6 +144,7 @@ def direct_download_url(path):
     )
     resource = response["Body"].read()
     return resource
+
 
 @app.route("/sim/dataset/<id>")
 def sim_dataset(id):

--- a/app/main.py
+++ b/app/main.py
@@ -250,6 +250,8 @@ def thumbnail_by_image_id(image_id, recursive_call=False):
     }
     response = requests.request("GET", url, headers=headers)
     encoded_content = base64.b64encode(response.content)
+    # Response from this endpoint is binary on success so the easiest thing to do is
+    # check for an error response in encoded form.
     if encoded_content == b'eyJzdGF0dXMiOiJBZG1pbiB1c2VyIGF1dGhlbnRpY2F0aW9uIHJlcXVpcmVkIHRvIHZpZXcvZWRpdCB1c2VyIGluZm8uIFlvdSBtYXkgbmVlZCB0byBsb2cgb3V0IGFuZCBsb2cgYmFjayBpbiB0byByZXZlcmlmeSB5b3VyIGNyZWRlbnRpYWxzLiJ9'\
             and not recursive_call:
         # Authentication failure, try again after resetting token.


### PR DESCRIPTION
# Description

When downloading files from the s3 bucket we now check the size of the download and reject files that are bigger then 20MB.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added two tests into the test_api file to download one small file and one big file.


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added unit tests that prove my fix is effective or that my feature works
