### PR TITLE
Fixing get datasets by project

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -215,7 +215,8 @@ def datasets_by_project_id(project_id):
     json = req.json()["records"]
 
     # 2 - filter response to retain only awards with project_id
-    result = filter(lambda x: x["properties"]["hasAwardNumber"] == project_id, json)
+    result1 = filter(lambda x: "hasAwardNumber" in x["properties"], json)
+    result = filter(lambda x: x["properties"]["hasAwardNumber"] == project_id, result1)
 
     ids = map(lambda x: str(x["datasetId"]), result)
 

--- a/app/main.py
+++ b/app/main.py
@@ -215,8 +215,7 @@ def datasets_by_project_id(project_id):
     json = req.json()["records"]
 
     # 2 - filter response to retain only awards with project_id
-    result1 = filter(lambda x: "hasAwardNumber" in x["properties"], json)
-    result = filter(lambda x: x["properties"]["hasAwardNumber"] == project_id, result1)
+    result = filter(lambda x: "hasAwardNumber" in x["properties"] and x["properties"]["hasAwardNumber"] == project_id, json)
 
     ids = map(lambda x: str(x["datasetId"]), result)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,3 +19,14 @@ def test_get_owner_email(client):
 
   r = client.get(f"/get_owner_email/{999999}")
   assert r.status_code == 404
+
+def test_get_datasets_by_project(client):
+  # SPARC Portal project info
+  portal_project_id = 'OT2OD023848'
+
+  r = client.get(f"/project/{999999}")
+  assert r.status_code == 404
+
+  r = client.get(f"/project/{portal_project_id}")
+  assert r.status_code == 200
+


### PR DESCRIPTION
# Description

This PR aims to restore function for the "get datasets by project id" endpoint. It is currently broken if a record does not have a "hasAwardNumber" key. This checks for existence of the key before filtering on the value of this key.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test was added for the function

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added unit tests that prove my fix is effective or that my feature works
