### PR TITLE
Remove packages that no longer exist on PYPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ docutils==0.15.2
 Flask==1.1.1
 flask-marshmallow==0.10.1
 flask-cors==3.0.8
-get==2019.4.13
 gunicorn==20.0.4
 idna==2.8
 itsdangerous==1.1.0
@@ -18,13 +17,11 @@ jmespath==0.9.4
 MarkupSafe==1.1.1
 marshmallow==3.2.2
 nose==1.3.7
-post==2019.4.13
 public==2019.4.13
 pymongo==3.8.0
 python-dateutil==2.8.0
 python-dotenv==0.10.3
 query-string==2019.4.13
-request==2019.4.13
 requests==2.22.0
 s3transfer==0.2.1
 six==1.13.0


### PR DESCRIPTION
# Description
Some of our dependencies have been removed from PyPI, see https://stackoverflow.com/a/63344555/2217801.
This pull request removes those dependencies and fixes issue #23 
To reproduce the error:
```
git clone https://github.com/nih-sparc/sparc-api.git
pip install -r requirements.txt
```
Which stops giving the error:

```
ERROR: Could not find a version that satisfies the requirement post==2019.4.13g
```

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested endpoints locally and on heroku.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests that prove my fix is effective or that my feature works
