### PR TITLE
Implementation of the share link api for map.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,7 @@ class Config(object):
     BLACKFYNN_API_SECRET = os.environ.get("BLACKFYNN_API_SECRET", "local-secret-key")
     BLACKFYNN_API_TOKEN = os.environ.get("BLACKFYNN_API_TOKEN", "local-api-key")
     BLACKFYNN_EMBARGO_TEAM_ID = os.environ.get("BLACKFYNN_EMBARGO_TEAM_ID")
+    DATABASE_URL = os.environ.get('DATABASE_URL')
     DISCOVER_API_HOST = os.environ.get(
         "DISCOVER_API_HOST", "https://api.blackfynn.io/discover"
     )
@@ -30,3 +31,4 @@ class Config(object):
     KNOWLEDGEBASE_KEY = os.environ.get("KNOWLEDGEBASE_KEY", "secret-key")
     DEPLOY_ENV = os.environ.get("DEPLOY_ENV", "development")
     SPARC_APP_HOST = os.environ.get("SPARC_APP_HOST", "https://sparc-app.herokuapp.com")
+    MAPSTATE_TABLENAME = os.environ.get("MAPSTATE_TABLENAME", "mapstates")

--- a/app/main.py
+++ b/app/main.py
@@ -313,7 +313,7 @@ def authenticate_biolucida():
 
 
 #get the share link for the current map content
-@app.route("/map/getsharelink", methods=["POST"])
+@app.route("/map/getshareid", methods=["POST"])
 def get_share_link():
     #Do not commit to database when testing
     commit = True

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from flask_cors import CORS
 from flask_marshmallow import Marshmallow
 from blackfynn import Blackfynn
 from app.config import Config
+from app.mapstate import MapState
 
 # from blackfynn import Blackfynn
 from app.serializer import ContactRequestSchema
@@ -38,6 +39,10 @@ s3 = boto3.client(
 
 biolucida_lock = Lock()
 
+try:
+  mapstate = MapState(Config.DATABASE_URL)
+except:
+  mapstate = None
 
 class Biolucida(object):
     _token = ''
@@ -305,3 +310,36 @@ def authenticate_biolucida():
     if response.status_code == requests.codes.ok:
         content = response.json()
         bl.set_token(content['token'])
+
+
+#get the share link for the current map content
+@app.route("/map/getsharelink", methods=["POST"])
+def get_share_link():
+    #Do not commit to database when testing
+    commit = True
+    if app.config["TESTING"]:
+        commit = False
+    if mapstate:
+        json_data = request.get_json()
+        if json_data and 'state' in json_data:
+            state = json_data['state']
+            uuid = mapstate.pushState(state, commit)
+            return jsonify({"uuid": uuid})
+        abort(400, description="State not specified")
+    else:
+        abort(404, description="Database not available")
+
+
+#get the map state using the share link id
+@app.route("/map/getstate", methods=["POST"])
+def get_map_state():
+    if mapstate:
+        json_data = request.get_json()
+        if json_data and 'uuid' in json_data:
+            uuid = json_data['uuid']
+            state = mapstate.pullState(uuid)
+            if state:
+                return jsonify({"state": mapstate.pullState(uuid)})
+        abort(400, description="Key missing or did not find a match")
+    else:
+        abort(404, description="Database not available")

--- a/app/mapstate.py
+++ b/app/mapstate.py
@@ -1,0 +1,44 @@
+from app.config import Config
+from sqlalchemy import create_engine  
+from sqlalchemy import Column, String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.declarative import declarative_base  
+from sqlalchemy.orm import sessionmaker
+import json
+import uuid
+
+#use the declarative syntax of sqlalchemy
+base = declarative_base()
+
+class State(base):  
+    __tablename__ = Config.MAPSTATE_TABLENAME
+    uuid = Column(String, primary_key=True, unique=True)
+    data = Column(JSONB)
+
+class MapState:
+  
+  def __init__(self, databaseURL):
+      db = create_engine(databaseURL)
+      global base
+      base.metadata.create_all(db)
+      Session = sessionmaker(db)
+      self._session = Session()
+
+  #push the state into the database and return an unique id
+  def pushState(self, input, commit = False):
+      id = uuid.uuid4().hex[:8]
+      #get a new key in the rare case of duplication
+      while self._session.query(State).filter_by(uuid=id).first() is not None:
+          id = uuid.uuid4().hex[:8]
+      newState = State(uuid=id, data=input)
+      self._session.add(newState)
+      if commit:
+          self._session.commit()
+      return id
+
+  def pullState(self, id):
+    state = self._session.query(State).filter_by(uuid=id).first()
+    if state:
+      return state.data
+    else:
+      return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,7 @@ query-string==2019.4.13
 requests==2.22.0
 s3transfer==0.2.1
 six==1.13.0
+SQLAlchemy==1.3.20
 urllib3==1.25.7
 Werkzeug==0.16.0
+psycopg2-binary==2.8.6

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,3 +46,27 @@ def test_get_datasets_by_project(client):
 
   r = client.get(f"/project/{portal_project_id}")
   assert r.status_code == 200
+
+def test_map_get_share_link_and_state(client):
+  # mock json for testing
+  testData = { "state" : { "type" : "scaffold", "value": 1234 } }
+
+  r = client.post(f"/map/getsharelink", json = {})
+  assert r.status_code == 400
+
+  r = client.post(f"/map/getsharelink", json = testData)
+  assert r.status_code == 200
+  assert "uuid" in r.get_json()
+
+  r = client.post(f"/map/getstate", json = r.get_json())
+  assert r.status_code == 200
+  returned_data = r.get_json()
+  assert "state" in returned_data
+  assert returned_data["state"]["type"] == "scaffold"
+  assert returned_data["state"]["value"] == 1234
+
+  r = client.post(f"/map/getstate", json = {"uuid": "1234567"})
+  assert r.status_code == 400
+
+  r = client.post(f"/map/getstate", json = {})
+  assert r.status_code == 400

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,14 +47,14 @@ def test_get_datasets_by_project(client):
   r = client.get(f"/project/{portal_project_id}")
   assert r.status_code == 200
 
-def test_map_get_share_link_and_state(client):
+def test_map_get_share_id_and_state(client):
   # mock json for testing
   testData = { "state" : { "type" : "scaffold", "value": 1234 } }
 
-  r = client.post(f"/map/getsharelink", json = {})
+  r = client.post(f"/map/getshareid", json = {})
   assert r.status_code == 400
 
-  r = client.post(f"/map/getsharelink", json = testData)
+  r = client.post(f"/map/getshareid", json = testData)
   assert r.status_code == 200
   assert "uuid" in r.get_json()
 


### PR DESCRIPTION
# Description

This pull request includes two new API endpoints `/map/getshareid` and `/map/getstate` 

`/map/getshareid` takes in a state date and store it into the database (specified by the DATABASE_URL) database and returns the generated uuid

`/map/getstate` retrieve the state from the database using the previously generated uuid.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests have been implemented for testing. 
A live demo can be found [here](https://mapcore-demo.org/current/sparc-app/maps).
Use the button on the top right corner of the map application to get the share link.
Here is a [sample link](https://mapcore-demo.org/current/sparc-app/maps/?id=112fc346) with a generated id and associated store state.
The live demo above is deployed with a postgresql database with similar DATABASE_URL setup to the one uses on Herokuand should behave similarly.
I have also tested the sparc-app linked to my personal sparc-api deployed on heroku with the additional postgres setup and it works as intended.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
