### PR TITLE
Add optional contentType param for /download

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -118,9 +118,10 @@ def contact():
 def create_presigned_url(expiration=3600):
     bucket_name = "blackfynn-discover-use1"
     key = request.args.get("key")
+    contentType = request.args.get("contentType") or "application/octet-stream"
     response = s3.generate_presigned_url(
         "get_object",
-        Params={"Bucket": bucket_name, "Key": key, "RequestPayer": "requester"},
+        Params={"Bucket": bucket_name, "Key": key, "RequestPayer": "requester", "ResponseContentType": contentType},
         ExpiresIn=expiration,
     )
 
@@ -128,7 +129,7 @@ def create_presigned_url(expiration=3600):
 
 
 # Reverse proxy for objects from S3, a simple get object
-# operation. This is used by scaffoldvuer and its 
+# operation. This is used by scaffoldvuer and its
 # important to keep the relative <path> for accessing
 # other required files.
 @app.route("/s3-resource/<path:path>")


### PR DESCRIPTION
# Description

The purpose of this PR is to add an optional contentType param for the `/download` route. This will be used when a client wants to [override the response's content type](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_object). This will be used when a user wants to view a native browser file on the SPARC Portal.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Ran the SPARC Portal locally with a branch, and hit the following files. Unsupported filetypes default to downloading the file.

- jpg: http://localhost:3000/datasets/12?type=dataset - files / source / Dorsal
- text: http://localhost:3000/datasets/12?type=dataset - files
- pdf: http://localhost:3000/datasets/86?type=dataset - files/primary
- mp4: http://localhost:3000/datasets/54?type=dataset - files /derivative /sam-P21 BAT /ses-B3tub
- png: http://localhost:3000/datasets/12?type=dataset - files /docs /Interactive map /Images

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
