### PR TITLE
oSPARC viewers

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -23,7 +23,7 @@ class Config(object):
     SES_SENDER = os.environ.get("SES_SENDER")
     SPARC_PORTAL_AWS_KEY = os.environ.get("SPARC_PORTAL_USER_ID")
     SPARC_PORTAL_AWS_SECRET = os.environ.get("SPARC_PORTAL_USER_SECRET")
-    OSPARC_HOST = os.environ.get("OSPARC_HOST", "https://osparc.io")
+    OSPARC_API_HOST = os.environ.get("OSPARC_API_HOST", "https://osparc.io/v0")
     AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
     BIOLUCIDA_ENDPOINT = os.environ.get("BIOLUCIDA_ENDPOINT", "https://sparc.biolucida.net/api/v1")
     BIOLUCIDA_USERNAME = os.environ.get("BIOLUCIDA_USERNAME", "major-user")

--- a/app/main.py
+++ b/app/main.py
@@ -335,10 +335,12 @@ def build_filetypes_table(osparc_viewers):
 def sim_dataset(id):
     if request.method == "GET":
         req = requests.get("{}/datasets/{}".format(Config.DISCOVER_API_HOST, id))
-        json = req.json()
-        inject_markdown(json)
-        inject_template_data(json)
-        return jsonify(json)
+        if req.ok:
+            json = req.json()
+            inject_markdown(json)
+            inject_template_data(json)
+            return jsonify(json)
+        abort(404, description="Resource not found")
 
 @app.route("/get_osparc_data")
 def get_osparc_data():

--- a/app/main.py
+++ b/app/main.py
@@ -300,10 +300,12 @@ def inject_template_data(resp):
         "description": template_json.get("description"),
     }
 
+# Constructs a table with where keys are the normalized (lowercased) file types
+# and the values an array of possible viewers
 def build_filetypes_table(osparc_viewers):
     table = {}
     for viewer in osparc_viewers:
-        filetype = viewer["file_type"]
+        filetype = viewer["file_type"].lower()
         del viewer["file_type"]
         if not table.get(filetype, False):
             table[filetype] = []

--- a/app/main.py
+++ b/app/main.py
@@ -97,6 +97,11 @@ def get_osparc_file_viewers():
     req = requests.get(url = f'{Config.OSPARC_HOST}/v0/viewers/filetypes')
     viewers = req.json()
     osparc_data["file_viewers"] = viewers["data"]
+    osparc_data["file_viewers"].append({
+        "file_type": "JSON",
+        "redirection_url": "http://osparc.io/view?file_type=JSON",
+        "viewer_title": "JSON Blablabla"
+    })
     if not viewers_scheduler.running:
         logging.info('Starting scheduler for oSPARC viewers acquisition')
         viewers_scheduler.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ SQLAlchemy==1.3.20
 urllib3==1.25.7
 Werkzeug==0.16.0
 psycopg2-binary==2.8.6
+APScheduler==3.7.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -117,3 +117,13 @@ def test_subscribe_to_mailchimp(client):
         auth=auth
     )
     assert resp.status_code == 204
+
+def test_osparc_viewers(client):
+    r = client.get('/get_osparc_data')
+    assert r.status_code == 200
+    osparc_data = r.get_json()
+    assert 'file_viewers' in osparc_data
+
+def test_sim_dataset(client):
+    r = client.get('/sim/dataset/0')
+    assert r.status_code == 404


### PR DESCRIPTION
# Description

Small backend work for serving the list of oSPARC viewers to the frontend.
It uses the oSPARC API to get the available viewers and stores them in memory to serve them to the frontend.
It asks for the viewers:
* Once before the first request
* Once a day after that

env variable OSPARC_API_HOST defines the target oSPARC API, https://osparc.io/v0 by default.

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added two tests testing that ``/get_osparc_data`` always contains viewers information and that ``/sim/dataset/<id>`` raises an HttpException if Discover response is not ok.
## How to test
Check out https://github.com/nih-sparc/sparc-app/pull/251 and follow instructions on the PR


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
