### PR TITLE
Scaffoldstate

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -33,6 +33,7 @@ class Config(object):
     SPARC_APP_HOST = os.environ.get("SPARC_APP_HOST", "https://sparc-app.herokuapp.com")
     SCI_CRUNCH_HOST = os.environ.get("SCICRUNCH_HOST", "https://scicrunch.org/api/1/elastic/SPARC_Datasets_pr")
     MAPSTATE_TABLENAME = os.environ.get("MAPSTATE_TABLENAME", "mapstates")
+    SCAFFOLDSTATE_TABLENAME = os.environ.get("SCAFFOLDSTATE_TABLENAME", "scaffoldstates")
     WRIKE_TOKEN = os.environ.get("WRIKE_TOKEN")
     SIM_CORE_TECH_LEAD_WRIKE_ID = os.environ.get("SIM_CORE_TECH_LEAD_WRIKE_ID")
     MAP_CORE_TECH_LEAD_WRIKE_ID = os.environ.get("MAP_CORE_TECH_LEAD_WRIKE_ID")

--- a/app/dbtable.py
+++ b/app/dbtable.py
@@ -10,35 +10,48 @@ import uuid
 #use the declarative syntax of sqlalchemy
 base = declarative_base()
 
-class State(base):  
+class MapState(base):  
     __tablename__ = Config.MAPSTATE_TABLENAME
     uuid = Column(String, primary_key=True, unique=True)
     data = Column(JSONB)
 
-class MapState:
-  
-  def __init__(self, databaseURL):
+class ScaffoldState(base):  
+    __tablename__ = Config.SCAFFOLDSTATE_TABLENAME
+    uuid = Column(String, primary_key=True, unique=True)
+    data = Column(JSONB)
+
+class Table:
+  def __init__(self, databaseURL, state):
       db = create_engine(databaseURL)
       global base
       base.metadata.create_all(db)
       Session = sessionmaker(db)
       self._session = Session()
+      self._state = state
 
   #push the state into the database and return an unique id
   def pushState(self, input, commit = False):
       id = uuid.uuid4().hex[:8]
       #get a new key in the rare case of duplication
-      while self._session.query(State).filter_by(uuid=id).first() is not None:
+      while self._session.query(self._state).filter_by(uuid=id).first() is not None:
           id = uuid.uuid4().hex[:8]
-      newState = State(uuid=id, data=input)
+      newState = self._state(uuid=id, data=input)
       self._session.add(newState)
       if commit:
           self._session.commit()
       return id
 
   def pullState(self, id):
-    state = self._session.query(State).filter_by(uuid=id).first()
-    if state:
-      return state.data
+    result = self._session.query(self._state).filter_by(uuid=id).first()
+    if result:
+      return result.data
     else:
       return None
+
+class MapTable(Table):
+  def __init__(self, databaseURL):
+    Table.__init__(self, databaseURL, MapState)
+
+class ScaffoldTable(Table):
+  def __init__(self, databaseURL):
+    Table.__init__(self, databaseURL, ScaffoldState)

--- a/app/dbtable.py
+++ b/app/dbtable.py
@@ -22,36 +22,36 @@ class ScaffoldState(base):
 
 class Table:
   def __init__(self, databaseURL, state):
-      db = create_engine(databaseURL)
-      global base
-      base.metadata.create_all(db)
-      Session = sessionmaker(db)
-      self._session = Session()
-      self._state = state
+        db = create_engine(databaseURL)
+        global base
+        base.metadata.create_all(db)
+        Session = sessionmaker(db)
+        self._session = Session()
+        self._state = state
 
   #push the state into the database and return an unique id
   def pushState(self, input, commit = False):
-      id = uuid.uuid4().hex[:8]
-      #get a new key in the rare case of duplication
-      while self._session.query(self._state).filter_by(uuid=id).first() is not None:
-          id = uuid.uuid4().hex[:8]
-      newState = self._state(uuid=id, data=input)
-      self._session.add(newState)
-      if commit:
-          self._session.commit()
-      return id
+        id = uuid.uuid4().hex[:8]
+        #get a new key in the rare case of duplication
+        while self._session.query(self._state).filter_by(uuid=id).first() is not None:
+            id = uuid.uuid4().hex[:8]
+        newState = self._state(uuid=id, data=input)
+        self._session.add(newState)
+        if commit:
+            self._session.commit()
+        return id
 
   def pullState(self, id):
     result = self._session.query(self._state).filter_by(uuid=id).first()
     if result:
-      return result.data
+        return result.data
     else:
-      return None
+        return None
 
 class MapTable(Table):
-  def __init__(self, databaseURL):
-    Table.__init__(self, databaseURL, MapState)
+    def __init__(self, databaseURL):
+        Table.__init__(self, databaseURL, MapState)
 
 class ScaffoldTable(Table):
-  def __init__(self, databaseURL):
-    Table.__init__(self, databaseURL, ScaffoldState)
+    def __init__(self, databaseURL):
+        Table.__init__(self, databaseURL, ScaffoldState)

--- a/app/main.py
+++ b/app/main.py
@@ -42,12 +42,9 @@ s3 = boto3.client(
 
 try:
   os.environ["AWS_ACCESS_KEY_ID"] = Config.SPARC_PORTAL_AWS_KEY
-except:
-  print("SPARC_PORTAL_AWS_KEY not set")
-try:
   os.environ["AWS_SECRET_ACCESS_KEY"] = Config.SPARC_PORTAL_AWS_SECRET
 except:
-  print("SPARC_PORTAL_AWS_SECRET not set")
+  pass
 
 biolucida_lock = Lock()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,62 +42,62 @@ def test_get_owner_email(client):
     assert r.status_code == 404
 
 def test_get_datasets_by_project(client):
-  # SPARC Portal project info
-  portal_project_id = 'OT2OD025340'
+    # SPARC Portal project info
+    portal_project_id = 'OT2OD025340'
 
-  r = client.get(f"/project/{999999}")
-  assert r.status_code == 404
+    r = client.get(f"/project/{999999}")
+    assert r.status_code == 404
 
-  r = client.get(f"/project/{portal_project_id}")
-  assert r.status_code == 200
+    r = client.get(f"/project/{portal_project_id}")
+    assert r.status_code == 200
 
 def test_map_get_share_id_and_state(client):
-  # mock json for testing
-  testData = { "state" : { "type" : "scaffold", "value": 1234 } }
+    # mock json for testing
+    testData = { "state" : { "type" : "scaffold", "value": 1234 } }
 
-  r = client.post(f"/map/getshareid", json = {})
-  assert r.status_code == 400
+    r = client.post(f"/map/getshareid", json = {})
+    assert r.status_code == 400
 
-  r = client.post(f"/map/getshareid", json = testData)
-  assert r.status_code == 200
-  assert "uuid" in r.get_json()
+    r = client.post(f"/map/getshareid", json = testData)
+    assert r.status_code == 200
+    assert "uuid" in r.get_json()
 
-  r = client.post(f"/map/getstate", json = r.get_json())
-  assert r.status_code == 200
-  returned_data = r.get_json()
-  assert "state" in returned_data
-  assert returned_data["state"]["type"] == "scaffold"
-  assert returned_data["state"]["value"] == 1234
+    r = client.post(f"/map/getstate", json = r.get_json())
+    assert r.status_code == 200
+    returned_data = r.get_json()
+    assert "state" in returned_data
+    assert returned_data["state"]["type"] == "scaffold"
+    assert returned_data["state"]["value"] == 1234
 
-  r = client.post(f"/map/getstate", json = {"uuid": "1234567"})
-  assert r.status_code == 400
+    r = client.post(f"/map/getstate", json = {"uuid": "1234567"})
+    assert r.status_code == 400
 
-  r = client.post(f"/map/getstate", json = {})
-  assert r.status_code == 400
+    r = client.post(f"/map/getstate", json = {})
+    assert r.status_code == 400
 
 def test_scaffold_get_share_id_and_state(client):
-  # mock json for testing
-  testData = { "state" : { "far" : 12.32, "near": 0.23 } }
+    # mock json for testing
+    testData = { "state" : { "far" : 12.32, "near": 0.23 } }
 
-  r = client.post(f"/scaffold/getshareid", json = {})
-  assert r.status_code == 400
+    r = client.post(f"/scaffold/getshareid", json = {})
+    assert r.status_code == 400
 
-  r = client.post(f"/scaffold/getshareid", json = testData)
-  assert r.status_code == 200
-  assert "uuid" in r.get_json()
+    r = client.post(f"/scaffold/getshareid", json = testData)
+    assert r.status_code == 200
+    assert "uuid" in r.get_json()
 
-  r = client.post(f"/scaffold/getstate", json = r.get_json())
-  assert r.status_code == 200
-  returned_data = r.get_json()
-  assert "state" in returned_data
-  assert returned_data["state"]["far"] == 12.32
-  assert returned_data["state"]["near"] == 0.23
+    r = client.post(f"/scaffold/getstate", json = r.get_json())
+    assert r.status_code == 200
+    returned_data = r.get_json()
+    assert "state" in returned_data
+    assert returned_data["state"]["far"] == 12.32
+    assert returned_data["state"]["near"] == 0.23
 
-  r = client.post(f"/scaffold/getstate", json = {"uuid": "1234567"})
-  assert r.status_code == 400
+    r = client.post(f"/scaffold/getstate", json = {"uuid": "1234567"})
+    assert r.status_code == 400
 
-  r = client.post(f"/scaffold/getstate", json = {})
-  assert r.status_code == 400
+    r = client.post(f"/scaffold/getstate", json = {})
+    assert r.status_code == 400
 
 def test_create_wrike_task(client):
     r = client.post(f"/tasks", json = {"title":"test-integration-task-sparc-api"})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -75,6 +75,30 @@ def test_map_get_share_id_and_state(client):
   r = client.post(f"/map/getstate", json = {})
   assert r.status_code == 400
 
+def test_scaffold_get_share_id_and_state(client):
+  # mock json for testing
+  testData = { "state" : { "far" : 12.32, "near": 0.23 } }
+
+  r = client.post(f"/scaffold/getshareid", json = {})
+  assert r.status_code == 400
+
+  r = client.post(f"/scaffold/getshareid", json = testData)
+  assert r.status_code == 200
+  assert "uuid" in r.get_json()
+
+  r = client.post(f"/scaffold/getstate", json = r.get_json())
+  assert r.status_code == 200
+  returned_data = r.get_json()
+  assert "state" in returned_data
+  assert returned_data["state"]["far"] == 12.32
+  assert returned_data["state"]["near"] == 0.23
+
+  r = client.post(f"/map/getstate", json = {"uuid": "1234567"})
+  assert r.status_code == 400
+
+  r = client.post(f"/map/getstate", json = {})
+  assert r.status_code == 400
+
 def test_create_wrike_task(client):
     r = client.post(f"/tasks", json = {"title":"test-integration-task-sparc-api"})
     assert r.status_code == 400

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -93,10 +93,10 @@ def test_scaffold_get_share_id_and_state(client):
   assert returned_data["state"]["far"] == 12.32
   assert returned_data["state"]["near"] == 0.23
 
-  r = client.post(f"/map/getstate", json = {"uuid": "1234567"})
+  r = client.post(f"/scaffold/getstate", json = {"uuid": "1234567"})
   assert r.status_code == 400
 
-  r = client.post(f"/map/getstate", json = {})
+  r = client.post(f"/scaffold/getstate", json = {})
   assert r.status_code == 400
 
 def test_create_wrike_task(client):


### PR DESCRIPTION
# Description

Add APIs to store scaffold state similar to the one used by Map.

## Type of change

Delete those that don't apply.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests have been added to make sure this is run correctly. This can also be tested here: 

The following link should restored the scaffold to a specific viewport
https://alan-wu-sparc-app.herokuapp.com/datasets/scaffoldviewer?scaffold=105%2F2%2Ffiles%2Fderivative%2FScaffold%2FratStomach_metadata.json&id=ea8add74
New link will also be copied when the share link button is pressed at the top right corner of the scaffold viewer.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
