### PR TITLE
Fix error caused by using logging.warning incorrectly

### DIFF
--- a/app/scicrunch_processing_v_1_1_3.py
+++ b/app/scicrunch_processing_v_1_1_3.py
@@ -203,7 +203,7 @@ def sort_files_by_mime_type(obj_list):
 
         mapped_mime_type = _mapped_mime_type(mime_type, obj)
         if mapped_mime_type == NOT_SPECIFIED:
-            logging.warning('Unhandled mime type:', mime_type)
+            logging.warning(f'Unhandled mime type: {mime_type}')
         elif mapped_mime_type == SKIP:
             pass
         else:


### PR DESCRIPTION
# Description

The call to logging.warning is causing an error, this fixes it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally and on https://mapcore-demo.org/staging/sparc-app/

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ x I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
