### PR TITLE
Fixing two bugs when obtaining data for Biolucida image viewing

### DIFF
--- a/app/biolucida_process_results.py
+++ b/app/biolucida_process_results.py
@@ -1,0 +1,85 @@
+import re
+
+from xml.etree import ElementTree
+
+
+XMP_NS = {'xmp': 'http://ns.adobe.com/xap/1.0/', 'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'x': 'adobe:ns:meta/'}
+XMP_CORE_REGEXP = r"^XMP Core ([\d]+\.[\d]+\.[\d])$"
+
+
+def _process_5_5_0(xml):
+    xmp_info = {}
+    pixel_width_element = xml.find('.//rdf:Description[@xmp:PixelWidth]', XMP_NS)
+    if pixel_width_element is not None:
+        xmp_info['pixel_width'] = pixel_width_element.attrib[f'{{{XMP_NS["xmp"]}}}PixelWidth']
+    pixel_height_element = xml.find('.//rdf:Description[@xmp:PixelHeight]', XMP_NS)
+    if pixel_height_element is not None:
+        xmp_info['pixel_height'] = pixel_height_element.attrib[f'{{{XMP_NS["xmp"]}}}PixelHeight']
+    z_spacing_element = xml.find('.//rdf:Description[@xmp:SizeZ]', XMP_NS)
+    if z_spacing_element is not None:
+        xmp_info['z_spacing'] = z_spacing_element.attrib[f'{{{XMP_NS["xmp"]}}}SizeZ']
+
+    return xmp_info
+
+
+def _process_5_6_0(xml):
+    xmp_info = {}
+    pixel_width_element = xml.find('.//rdf:li[@xmp:PixelWidth]', XMP_NS)
+    if pixel_width_element is not None:
+        xmp_info['pixel_width'] = pixel_width_element.attrib[f'{{{XMP_NS["xmp"]}}}PixelWidth']
+    pixel_height_element = xml.find('.//rdf:li[@xmp:PixelHeight]', XMP_NS)
+    if pixel_height_element is not None:
+        xmp_info['pixel_height'] = pixel_height_element.attrib[f'{{{XMP_NS["xmp"]}}}PixelHeight']
+    z_spacing_element = xml.find('.//rdf:li[@xmp:SpacingZ]', XMP_NS)
+    if z_spacing_element is not None:
+        xmp_info['z_spacing'] = z_spacing_element.attrib[f'{{{XMP_NS["xmp"]}}}SpacingZ']
+
+    element = xml.find('.//rdf:li[@xmp:Description]', XMP_NS)
+    if element is not None:
+        image_description = element.attrib[f'{{{XMP_NS["xmp"]}}}Description']
+        image_description_mbf_map = image_description[image_description.find('<mbf_map>') + len('<mbf_map>'):]
+        mbf_map = image_description_mbf_map[:image_description_mbf_map.find('</mbf_map>')]
+
+        # Get the modality, expect it to be the same for all channels.
+        matched = re.findall(r'Channel:0:[0-9]+:AcquisitionMode\?([^?]+)\?', mbf_map)
+        matched = list(set(matched))
+        if len(matched) == 1:
+            xmp_info['modality'] = matched[0]
+        else:
+            xmp_info['modality'] = 'RGB'
+
+        # Get the channel colours and names.
+        matched_colour = re.findall(r'Channel:0:([0-9]+):Color\?([^?]+)\?', mbf_map)
+        matched_name = re.findall(r'Channel:0:([0-9]+):Name\?([^?]+)\?', mbf_map)
+        if len(matched_colour) == len(matched_name):
+            xmp_info['channel_colours'] = [{}] * len(matched_colour)
+            for name in matched_name:
+                index = int(name[0])
+                colour_list = [colour[1] for colour in matched_colour if colour[0] == name[0]]
+                colour = int(colour_list[0])
+                name = name[1]
+                xmp_info['channel_colours'][index] = {'colour': '#{0:06X}'.format((colour >> 8) & 0xffffff), 'label': name}
+
+        # Determine if image is 3D or 2D.
+        matched = re.findall(r'SizeZ\?([^?]+)\?', mbf_map)
+        if len(matched) == 1:
+            xmp_info['three_d'] = int(matched[0]) > 1
+
+    return xmp_info
+
+
+def process_results(data):
+    xml = ElementTree.fromstring(data)
+    xmp_version_string = xml.get(f"{{{XMP_NS['x']}}}xmptk")
+
+    match = re.match(XMP_CORE_REGEXP, xmp_version_string)
+    if match is not None:
+        version = match.group(1)
+        handling_function_name = f"_process_{version.replace('.', '_')}"
+        handling_function = globals().get(handling_function_name, None)
+        if handling_function is not None:
+            return handling_function(xml)
+
+        raise NotImplementedError(f"Not able to handle XMP core meta data for version: '{version}'")
+
+    raise AttributeError(f"Not able to match version from: '{xmp_version_string}'")

--- a/app/scicrunch_process_results.py
+++ b/app/scicrunch_process_results.py
@@ -27,7 +27,7 @@ def _prepare_results(results):
             attr['readme'] = ''
 
         try:
-            attr['title'] = hit['_source']['item']['names'][0]['name']
+            attr['title'] = hit['_source']['item']['name']
         except KeyError:
             attr['title'] = ''
 

--- a/tests/test_biolucida.py
+++ b/tests/test_biolucida.py
@@ -43,10 +43,23 @@ class BiolucidaTestCase(unittest.TestCase):
         self.assertTrue(thumbnail.startswith(b'/9j/4AAQSkZJRgABAQAAAQ'))
 
 
-def test_image_xmp_info(client):
+def test_image_xmp_info_2727(client):
     r = client.get('/image_xmp_info/2727')
+
     assert 'pixel_width' in r.json
+    assert 'channel_colours' in r.json
     assert r.json['pixel_width'] == "0.415133"
+    assert r.json['pixel_height'] == "0.415133"
+    assert r.json['z_spacing'] == "1.000000"
+
+
+def test_image_xmp_info_1197(client):
+    r = client.get('/image_xmp_info/1197')
+
+    assert 'pixel_width' in r.json
+    assert r.json['pixel_width'] == "0.008184"
+    assert r.json['pixel_height'] == "0.008184"
+    assert r.json['z_spacing'] == "-1.000000"
 
 
 if __name__ == '__main__':

--- a/tests/test_scicrunch.py
+++ b/tests/test_scicrunch.py
@@ -101,6 +101,23 @@ def test_getting_facets(client):
     assert 'heart' in facets
 
 
+def test_create_identifier_query(client):
+    r = client.get('/dataset_info/using_object_identifier?identifier=package:e6435710-dd9c-46b7-9dfd-932103469733')
+
+    json_data = json.loads(r.data)
+    assert 'result' in json_data
+
+    results = json_data['result']
+    assert len(results) == 1
+
+    result = results[0]
+    assert 'version' in result
+    assert result['version'] == '1.1.3'
+
+    assert 'title' in result
+    assert result['title'] == 'Morphometric analysis of the abdominal vagus nerve in rats'
+
+
 def test_response_version(client):
     # Testing with dataset 44
     identifier = "44"
@@ -114,6 +131,7 @@ def test_response_version(client):
         assert 'version' in json_data['result'][0]
     else:
         pytest.skip('DOI used in test is out of date.')
+
 
 def test_response_abi_plot(client):
     # Testing abi-plot with dataset 141
@@ -146,6 +164,7 @@ def test_response_abi_plot(client):
     else:
         pytest.skip('DOI used in test is out of date.')
 
+
 def test_response_sample_subject_size(client):
     #Only filter search returns the sample and subjectSuze
     r = client.get(('/filter-search/?facet=pig&term=species&facet=urinary+bladder&term=organ'))
@@ -155,6 +174,7 @@ def test_response_sample_subject_size(client):
     assert len(json_data['results']) == 1
     assert json_data['results'][0]['sampleSize'] == '509'
     assert json_data['results'][0]['subjectSize'] == '8'
+
 
 source_structure = {
     'type': dict,


### PR DESCRIPTION
# Description

Added ability to process version 5.5.0 XMP meta data in addition to version 5.6.0 XMP meta data.
Changed the location of where the dataset title is taken from in the Scicrunch result data structure.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have written and/or extended three unit tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
