### PR TITLE
Context files now passed through 'process_results'

### DIFF
--- a/app/scicrunch_process_results.py
+++ b/app/scicrunch_process_results.py
@@ -1,7 +1,7 @@
 import importlib
 import json
 import re
-
+from flask import jsonify
 
 # process_kb_results: Loop through SciCrunch results pulling out desired attributes and processing DOIs and CSV files
 def _prepare_results(results):
@@ -21,6 +21,12 @@ def _prepare_results(results):
         attr = _transform_attributes(attributes_map, hit)
         attr['doi'] = _convert_doi_to_url(attr['doi'])
         attr['took'] = results['took']
+        # find context files by looking through object mimetypes
+        attr['abi-contextual-information'] = [
+            file['dataset']['path']
+            for file in hit['_source']['objects']
+            if file['additional_mimetype']['name'].find('context') is not -1
+        ]
         try:
             attr['readme'] = hit['_source']['item']['readme']['description']
         except KeyError:
@@ -38,7 +44,7 @@ def _prepare_results(results):
 
 
 def process_results(results):
-    return json.dumps({'numberOfHits': results['hits']['total'], 'results': _prepare_results(results)})
+    return jsonify({'numberOfHits': results['hits']['total'], 'results': _prepare_results(results)})
 
 
 def reform_dataset_results(results):

--- a/app/scicrunch_process_results.py
+++ b/app/scicrunch_process_results.py
@@ -25,7 +25,7 @@ def _prepare_results(results):
         attr['abi-contextual-information'] = [
             file['dataset']['path']
             for file in hit['_source']['objects']
-            if file['additional_mimetype']['name'].find('context') is not -1
+            if file['additional_mimetype']['name'].find('abi.context-information') is not -1
         ]
         try:
             attr['readme'] = hit['_source']['item']['readme']['description']

--- a/app/scicrunch_processing_common.py
+++ b/app/scicrunch_processing_common.py
@@ -13,6 +13,7 @@ SCAFFOLD_DIR = 'abi-scaffold-dir'
 SCAFFOLD_FILE = 'abi-scaffold-metadata-file'
 SCAFFOLD_THUMBNAIL = 'abi-scaffold-thumbnail'
 SCAFFOLD_VIEW_FILE = 'abi-scaffold-view-file'
+CONTEXT_FILE = 'abi-context-file'
 VIDEO = 'video'
 VERSION = 'version'
 README = 'readme'
@@ -32,6 +33,7 @@ MAPPED_MIME_TYPES = {
     'inode/vnd.abi.scaffold+thumbnail': SCAFFOLD_THUMBNAIL,
     'inode/vnd.abi.scaffold.thumbnail+file': SCAFFOLD_THUMBNAIL,
     'inode/vnd.abi.scaffold.view+file': SCAFFOLD_VIEW_FILE,
+    'application/x.abi.context-information+json': CONTEXT_FILE,
     'text/vnd.abi.plot+Tab-separated-values': PLOT_FILE,
     'text/vnd.abi.plot+csv': PLOT_FILE,
     'image/png': COMMON_IMAGES,

--- a/app/scicrunch_processing_common.py
+++ b/app/scicrunch_processing_common.py
@@ -33,7 +33,7 @@ MAPPED_MIME_TYPES = {
     'inode/vnd.abi.scaffold+thumbnail': SCAFFOLD_THUMBNAIL,
     'inode/vnd.abi.scaffold.thumbnail+file': SCAFFOLD_THUMBNAIL,
     'inode/vnd.abi.scaffold.view+file': SCAFFOLD_VIEW_FILE,
-    'application/vnd.abi.context-information+json': CONTEXT_FILE,
+    'application/x.vnd.abi.context-information+json': CONTEXT_FILE,
     'text/vnd.abi.plot+Tab-separated-values': PLOT_FILE,
     'text/vnd.abi.plot+csv': PLOT_FILE,
     'image/png': COMMON_IMAGES,

--- a/app/scicrunch_processing_common.py
+++ b/app/scicrunch_processing_common.py
@@ -33,7 +33,7 @@ MAPPED_MIME_TYPES = {
     'inode/vnd.abi.scaffold+thumbnail': SCAFFOLD_THUMBNAIL,
     'inode/vnd.abi.scaffold.thumbnail+file': SCAFFOLD_THUMBNAIL,
     'inode/vnd.abi.scaffold.view+file': SCAFFOLD_VIEW_FILE,
-    'application/x.abi.context-information+json': CONTEXT_FILE,
+    'application/vnd.abi.context-information+json': CONTEXT_FILE,
     'text/vnd.abi.plot+Tab-separated-values': PLOT_FILE,
     'text/vnd.abi.plot+csv': PLOT_FILE,
     'image/png': COMMON_IMAGES,

--- a/tests/test_scicrunch.py
+++ b/tests/test_scicrunch.py
@@ -424,3 +424,11 @@ def test_scaffold_files(client):
             key = f"{uri}files/{path}".replace('s3://pennsieve-prod-discover-publish-use1/', '')
             r = client.get(f"/s3-resource/{key}")
             assert r.status_code == 200
+
+def test_contextual_information(client):
+    r = client.get('/dataset_info/using_multiple_discoverIds/?discoverIds=76')
+    results = json.loads(r.data)
+    assert results['numberOfHits'] > 0
+    for item in results['results']:
+        if 'abi-contextual-information' in item:
+            assert r.status_code == 200

--- a/tests/test_scicrunch.py
+++ b/tests/test_scicrunch.py
@@ -425,10 +425,9 @@ def test_scaffold_files(client):
             r = client.get(f"/s3-resource/{key}")
             assert r.status_code == 200
 
-def test_contextual_information(client):
+def test_finding_contextual_information(client):
     r = client.get('/dataset_info/using_multiple_discoverIds/?discoverIds=76')
     results = json.loads(r.data)
-    assert results['numberOfHits'] > 0
+    assert results['numberOfHits'] > 0  # Test we could find the generic colon scaffold dataset
     for item in results['results']:
-        if 'abi-contextual-information' in item:
-            assert r.status_code == 200
+        assert len(item['abi-contextual-information']) > 0  # Check it has contextual information


### PR DESCRIPTION
# Description

This change adds some extra processing to send context files to the map sidebar from scicrunch. 

This is needed for this milestone:
https://www.wrike.com/open.htm?id=688989087

They are used to display some information alongside a scaffold like so:
![image](https://user-images.githubusercontent.com/37255664/158483017-84336cf6-0ab1-49ec-9485-b832a1239d42.png)

**Note: this feature currently only works in https://scicrunch.org/api/1/elastic/SPARC_PortalDatasets_stage** 

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
