### PR TITLE
Download endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -175,7 +175,6 @@ def create_s3_presigned_url(key, content_type, expiration):
     return response
 
 
-# Download a file from S3
 @app.route("/download-link")
 def create_presigned_url(expiration=3600):
     key = request.args.get("key")
@@ -184,6 +183,7 @@ def create_presigned_url(expiration=3600):
     return create_s3_presigned_url(key, content_type, expiration)
 
 
+# Download a file from S3
 @app.route("/download")
 def download_file(expiration=3600):
     key = request.args.get("key")
@@ -191,6 +191,7 @@ def download_file(expiration=3600):
 
     presigned_url = create_s3_presigned_url(key, content_type, expiration)
     return redirect(presigned_url)
+
 
 @app.route("/thumbnail/neurolucida")
 def thumbnail_from_neurolucida_file():

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ import requests
 from apscheduler.schedulers.background import BackgroundScheduler
 from botocore.exceptions import ClientError
 from datetime import datetime, timedelta
-from flask import Flask, abort, jsonify, request
+from flask import Flask, abort, jsonify, request, redirect
 from flask_cors import CORS
 from flask_marshmallow import Marshmallow
 from pennsieve import Pennsieve
@@ -176,13 +176,21 @@ def create_s3_presigned_url(key, content_type, expiration):
 
 
 # Download a file from S3
-@app.route("/download")
+@app.route("/download-link")
 def create_presigned_url(expiration=3600):
     key = request.args.get("key")
     content_type = request.args.get("contentType") or "application/octet-stream"
 
     return create_s3_presigned_url(key, content_type, expiration)
 
+
+@app.route("/download")
+def download_file(expiration=3600):
+    key = request.args.get("key")
+    content_type = request.args.get("contentType") or "application/octet-stream"
+
+    presigned_url = create_s3_presigned_url(key, content_type, expiration)
+    return redirect(presigned_url)
 
 @app.route("/thumbnail/neurolucida")
 def thumbnail_from_neurolucida_file():


### PR DESCRIPTION
# Description

Old ``/download`` endpoint gets renamed to ``/download-link`` and a new ``/download`` endpoint is added. This one redirects to the obtained file URL instead of returning it as a string.

**Goes together with https://github.com/nih-sparc/sparc-app/pull/452**

## Type of change

- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Manually


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works