### PR TITLE
Added readme endpoint for searching docs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -49,3 +49,4 @@ class Config(object):
     NEUROLUCIDA_HOST = os.environ.get("NEUROLUCIDA_HOST", "https://sparc.biolucida.net:8081")
     SCI_CRUNCH_INTERLEX_HOST = os.environ.get("SCI_CRUNCH_INTERLEX_HOST", "https://scicrunch.org/api/1/elastic/Interlex_pr")
     SENDGRID_API_KEY =  os.environ.get("SENDGRID_API_KEY")
+    README_API_KEY =  os.environ.get("README_API_KEY")

--- a/app/main.py
+++ b/app/main.py
@@ -1006,3 +1006,13 @@ def find_by_onto_term():
         json_data = {'label': 'not found'}
 
     return json_data
+
+@app.route("/search-readme/<query>", methods=["GET"])
+def search_readme(query):
+    url = 'https://dash.readme.com/api/v1/docs/search?search={query}'
+    headers = { 'Authorization': 'Basic ' + Config.README_API_KEY }
+    response = requests.post(
+        url = url,
+        headers = headers
+    )
+    return response.json()['results']


### PR DESCRIPTION
# Description

Added an endpoint for searching readme docs via their API. This must be done from the sparc-api since we cannot access it via the client due to CORS as outlined here: https://docs.readme.com/discuss/6218c70671f38803484f8b36

## Type of change

Delete those that don't apply.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

None since I cannot get the api running locally. I will test the endpoint once it is on staging. Since it is added functionality it will not affect/break anything else

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
