### PR TITLE
downgraded protobuf version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ urllib3==1.26.4
 Werkzeug==0.16.0
 psycopg2-binary==2.8.6
 APScheduler==3.7.0
+protobuf==3.20.1


### PR DESCRIPTION
# Description

Tests are failing as a result of https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates. 

Downgraded protobuf version to 3.20.1 as suggested

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Did not test locally, am just going to let daily tests run and see results

