### PR TITLE
Revert "downgraded protobuf version"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,3 @@ urllib3==1.26.4
 Werkzeug==0.16.0
 psycopg2-binary==2.8.6
 APScheduler==3.7.0
-protobuf==3.20.1


### PR DESCRIPTION
Reverts nih-sparc/sparc-api#86
Unfortunately 3.20.1 is not available on Heroku due to the older python version there.
I will be setting PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python on the test environment to work around this issue for now.