### PR TITLE
Add endpoint to send email to comms w/ attachment

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,7 @@ class Config(object):
     MONGODB_URI = os.environ.get("MONGODB_URI")
     SES_ARN = os.environ.get("SES_ARN")
     SES_SENDER = os.environ.get("SES_SENDER")
+    COMMS_EMAIL = os.environ.get("COMMS_EMAIL")
     SPARC_PORTAL_AWS_KEY = os.environ.get("SPARC_PORTAL_USER_ID")
     SPARC_PORTAL_AWS_SECRET = os.environ.get("SPARC_PORTAL_USER_SECRET")
     OSPARC_API_HOST = os.environ.get("OSPARC_API_HOST", "https://osparc.io/v0")


### PR DESCRIPTION
# Description

Added an endpoint to email comms in order to submit a request for a news, event, success story, or fireside chat to get created.

Created a new sendgrid email method to allow for attaching a file to the email that gets sent 

## Type of change

Delete those that don't apply.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
