### PR TITLE
fixed has attachment bug

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -200,7 +200,7 @@ def email_comms():
     else:
       abort(400, description="Incorrect submission form type!")
 
-    if has_attachment:
+    if has_attachment == 'true':
       files = request.files
       if files and 'attachment_file' in files:
         attachment_file = files['attachment_file']


### PR DESCRIPTION
# Description

Fixed bug as per: https://www.wrike.com/workspace.htm?acc=3203588#/task-view?id=964959416&pid=825398997&cid=441356195. We were doing a boolean check on a string so it was always equating to true for file attachments even if one was not sent.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
