### PR TITLE
Osparc viewers bug

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -124,7 +124,7 @@ viewers_scheduler = BackgroundScheduler()
 def get_osparc_file_viewers():
     logging.info('Getting oSPARC viewers')
     # Gets a list of default viewers.
-    req = requests.get(url=f'{Config.OSPARC_API_HOST}/viewers/default')
+    req = requests.get(url=f'{Config.OSPARC_API_HOST}/viewers')
     viewers = req.json()
     table = build_filetypes_table(viewers["data"])
     osparc_data["file_viewers"] = table


### PR DESCRIPTION
# Description

Corrected bug where only default viewers were retrieved from the oSPARC API. Now all of the available viewers are retrieved for the user to choose among them.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Manually


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
