### PR TITLE
Added attachment option to tasks endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -923,7 +923,26 @@ def create_wrike_task():
             headers=hed
         )
 
-        if resp.status_code == 200:
+        if ('attachment' in json_data and json_data['attachment'] != '' and 'data' in resp.json() and resp.json()["data"] != []):
+            attachment = json_data['attachment']
+            task_id = resp.json()["data"][0]["id"]
+            headers = {
+                'Authorization': 'Bearer ' + Config.WRIKE_TOKEN,
+                'X-File-Name': attachment,
+                'content-type': 'application/octet-stream',
+                'X-Requested-With': 'XMLHttpRequest'
+              }
+            attachmentUrl = "https://www.wrike.com/api/v4/tasks/" + task_id + "/attachments"
+
+            attachmentResp = requests.post(
+                url=attachmentUrl,
+                json={},
+                headers=headers
+            )
+
+            if (attachmentResp.status_code != 200):
+              print("File attachment for task with id: " + task_id + " failed to attach to wrike ticket")
+        if (resp.status_code == 200):
 
             if 'userEmail' in json_data and json_data['userEmail'] is not None:
                 email_sender.sendgrid_email(Config.SES_SENDER, json_data['userEmail'], 'Issue reporting', issue_reporting_email.substitute({ 'message': json_data['description'] }))


### PR DESCRIPTION
# Description

Added the ability to pass an attachment to the tasks endpoint in order to attach an image to a wrike ticket

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Not yet tested as the Wrike API token is not working. Will test on staging once the env variables are updated. Will not hurt anything as it is currently not working on staging or prod now anyways

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
