### PR TITLE
Metrics API (second try)

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,0 +1,2 @@
+export GOOGLE_API_GA_KEY_PATH=$HOME/ga-credentials.json
+echo ${GOOGLE_API_GA_CONFIG} > ${GOOGLE_API_GA_KEY_PATH}

--- a/.profile
+++ b/.profile
@@ -1,2 +1,2 @@
 export GOOGLE_API_GA_KEY_PATH=$HOME/ga-credentials.json
-echo ${GOOGLE_API_GA_CONFIG} > ${GOOGLE_API_GA_KEY_PATH}
+echo "${GOOGLE_API_GA_CONFIG}" > "${GOOGLE_API_GA_KEY_PATH}"

--- a/app/config.py
+++ b/app/config.py
@@ -58,7 +58,7 @@ class Config(object):
     GOOGLE_API_GA_VIEW_ID = os.environ.get("GOOGLE_API_GA_VIEW_ID", "198433812")
     ALGOLIA_APP_ID = os.environ.get("ALGOLIA_APP_ID")
     ALGOLIA_API_KEY = os.environ.get("ALGOLIA_API_KEY")
-    ALGOLIA_API_INDEX = os.environ.get("ALGOLIA_API_INDEX", "k-core_dev")
+    ALGOLIA_INDEX = os.environ.get("ALGOLIA_INDEX", "k-core_dev")
     CTF_API_HOST = os.environ.get("CTF_API_HOST", "preview.contentful.com")
     CTF_CDA_ACCESS_TOKEN = os.environ.get("CTF_CDA_ACCESS_TOKEN")
     CTF_SPACE_ID = os.environ.get("CTF_SPACE_ID")

--- a/app/config.py
+++ b/app/config.py
@@ -52,3 +52,13 @@ class Config(object):
     SCI_CRUNCH_SCIGRAPH_HOST = os.environ.get("SCI_CRUNCH_SCIGRAPH_HOST", "https://scicrunch.org/api/1/sparc-scigraph")
     SENDGRID_API_KEY =  os.environ.get("SENDGRID_API_KEY")
     README_API_KEY =  os.environ.get("README_API_KEY")
+    # Metrics
+    GOOGLE_API_GA_SCOPE = os.environ.get("GOOGLE_API_GA_SCOPE", "https://www.googleapis.com/auth/analytics.readonly")
+    GOOGLE_API_GA_KEY_PATH = os.environ.get("GOOGLE_API_GA_KEY_PATH")
+    GOOGLE_API_GA_VIEW_ID = os.environ.get("GOOGLE_API_GA_VIEW_ID", "198433812")
+    ALGOLIA_APP_ID = os.environ.get("ALGOLIA_APP_ID")
+    ALGOLIA_API_KEY = os.environ.get("ALGOLIA_API_KEY")
+    ALGOLIA_API_INDEX = os.environ.get("ALGOLIA_API_INDEX", "k-core_dev")
+    CTF_API_HOST = os.environ.get("CTF_API_HOST", "preview.contentful.com")
+    CTF_CDA_ACCESS_TOKEN = os.environ.get("CTF_CDA_ACCESS_TOKEN")
+    CTF_SPACE_ID = os.environ.get("CTF_SPACE_ID")

--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,8 @@ from app.utilities import img_to_base64_str
 from app.osparc import run_simulation
 from app.biolucida_process_results import process_results as process_biolucida_results
 
+logging.basicConfig()
+
 app = Flask(__name__)
 # set environment variable
 app.config["ENV"] = Config.DEPLOY_ENV

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,11 @@
 import atexit
 import base64
+
+from app.metrics.pennsieve import get_download_count
+from app.metrics.contentful import init_cf_client, get_funded_projects_count
+from app.metrics.algolia import get_dataset_count, init_algolia_client
+from app.metrics.ga import init_ga_reporting, get_ga_1year_sessions
+
 import boto3
 import json
 import logging
@@ -118,6 +124,7 @@ def connect_to_pennsieve():
 
 
 viewers_scheduler = BackgroundScheduler()
+metrics_scheduler = BackgroundScheduler()
 
 
 @app.before_first_request
@@ -133,17 +140,45 @@ def get_osparc_file_viewers():
         viewers_scheduler.start()
 
 
+usage_metrics = {}
+google_analytics = init_ga_reporting()
+algolia = init_algolia_client()
+contentful = init_cf_client()
+
+
+@app.before_first_request
+def get_metrics():
+    logging.info('Gathering metrics data')
+    ga_response = get_ga_1year_sessions(google_analytics)
+    algolia_response = get_dataset_count(algolia)
+    cf_response = get_funded_projects_count(contentful)
+    ps_response = get_download_count()
+    usage_metrics['1year_sessions_count'] = ga_response
+    usage_metrics['dataset_count'] = algolia_response
+    usage_metrics['funded_projects_count'] = cf_response
+    usage_metrics['1year_download_count'] = ps_response
+    if not metrics_scheduler.running:
+        logging.info('Starting scheduler for metrics acquisition')
+        metrics_scheduler.start()
+    
+
 # Gets oSPARC viewers before the first request after startup and then once a day.
 viewers_scheduler.add_job(func=get_osparc_file_viewers, trigger="interval", days=1)
 
+# Gathers all the required metrics, once every three hours
+metrics_scheduler.add_job(func=get_metrics, trigger='interval', hours=3)
 
-def shutdown_scheduler():
+
+def shutdown_schedulers():
     logging.info('Stopping scheduler for oSPARC viewers acquisition')
     if viewers_scheduler.running:
         viewers_scheduler.shutdown()
+    logging.info('Stopping scheduler for metrics acquisition')
+    if metrics_scheduler.running:
+        metrics_scheduler.shutdown()
 
 
-atexit.register(shutdown_scheduler)
+atexit.register(shutdown_schedulers)
 
 
 @app.route("/health")
@@ -1170,3 +1205,7 @@ def search_readme(query):
     except requests.exceptions.HTTPError as err:
         logging.error(err)
         return jsonify({'error': str(err), 'message': 'Readme is not currently reachable, please try again later'}), 502
+
+@app.route("/metrics", methods=["GET"])
+def metrics():
+    return usage_metrics

--- a/app/main.py
+++ b/app/main.py
@@ -151,14 +151,22 @@ contentful = init_cf_client()
 @app.before_first_request
 def get_metrics():
     logging.info('Gathering metrics data')
-    ga_response = get_ga_1year_sessions(google_analytics)
-    algolia_response = get_dataset_count(algolia)
-    cf_response = get_funded_projects_count(contentful)
+
+    if google_analytics:
+        ga_response = get_ga_1year_sessions(google_analytics)
+        usage_metrics['1year_sessions_count'] = ga_response
+
+    if algolia:
+        algolia_response = get_dataset_count(algolia)
+        usage_metrics['dataset_count'] = algolia_response
+
+    if contentful:
+        cf_response = get_funded_projects_count(contentful)
+        usage_metrics['funded_projects_count'] = cf_response
+        
     ps_response = get_download_count()
-    usage_metrics['1year_sessions_count'] = ga_response
-    usage_metrics['dataset_count'] = algolia_response
-    usage_metrics['funded_projects_count'] = cf_response
     usage_metrics['1year_download_count'] = ps_response
+
     if not metrics_scheduler.running:
         logging.info('Starting scheduler for metrics acquisition')
         metrics_scheduler.start()

--- a/app/metrics/algolia.py
+++ b/app/metrics/algolia.py
@@ -1,0 +1,16 @@
+from algoliasearch.search_client import SearchClient
+from app.config import Config
+
+APP_ID = Config.ALGOLIA_APP_ID
+API_KEY = Config.ALGOLIA_API_KEY
+INDEX = Config.ALGOLIA_API_INDEX
+
+
+def init_algolia_client():
+    return SearchClient.create(APP_ID, API_KEY)
+
+
+def get_dataset_count(client):
+    index = client.init_index(INDEX)
+    res = index.search("")
+    return res["nbHits"]

--- a/app/metrics/algolia.py
+++ b/app/metrics/algolia.py
@@ -3,7 +3,7 @@ from app.config import Config
 
 APP_ID = Config.ALGOLIA_APP_ID
 API_KEY = Config.ALGOLIA_API_KEY
-INDEX = Config.ALGOLIA_API_INDEX
+INDEX = Config.ALGOLIA_INDEX
 
 
 def init_algolia_client():

--- a/app/metrics/algolia.py
+++ b/app/metrics/algolia.py
@@ -1,3 +1,5 @@
+import logging
+
 from algoliasearch.search_client import SearchClient
 from app.config import Config
 
@@ -7,7 +9,11 @@ INDEX = Config.ALGOLIA_INDEX
 
 
 def init_algolia_client():
-    return SearchClient.create(APP_ID, API_KEY)
+    try:
+        return SearchClient.create(APP_ID, API_KEY)
+    except Exception as e:
+        logging.error('An error occured while instantiating the Algolia search client.', e)
+        return None
 
 
 def get_dataset_count(client):

--- a/app/metrics/algolia.py
+++ b/app/metrics/algolia.py
@@ -11,6 +11,7 @@ INDEX = Config.ALGOLIA_INDEX
 def init_algolia_client():
     try:
         return SearchClient.create(APP_ID, API_KEY)
+        
     except Exception as e:
         logging.error('An error occured while instantiating the Algolia search client.', e)
         return None

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -1,0 +1,25 @@
+from email import contentmanager
+
+from app.config import Config
+
+import contentful
+
+API_HOST = Config.CTF_API_HOST
+ACCESS_TOKEN = Config.CTF_CDA_ACCESS_TOKEN
+SPACE_ID = Config.CTF_SPACE_ID
+
+
+def init_cf_client():
+    client = contentful.Client(
+        SPACE_ID,
+        ACCESS_TOKEN,
+        api_url=API_HOST
+    )
+    return client
+
+
+def get_funded_projects_count(client):
+    response = client.entries({
+        "content_type": "sparcAward"
+    })
+    return response.total

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -1,4 +1,4 @@
-from email import contentmanager
+import logging
 
 from app.config import Config
 
@@ -10,12 +10,17 @@ SPACE_ID = Config.CTF_SPACE_ID
 
 
 def init_cf_client():
-    client = contentful.Client(
-        SPACE_ID,
-        ACCESS_TOKEN,
-        api_url=API_HOST
-    )
-    return client
+    try:
+        client = contentful.Client(
+            SPACE_ID,
+            ACCESS_TOKEN,
+            api_url=API_HOST
+        )
+        return client
+        
+    except Exception as e:
+        logging.error('An error occured while instantiating the Contentful client.', e)
+        return None
 
 
 def get_funded_projects_count(client):

--- a/app/metrics/ga.py
+++ b/app/metrics/ga.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+
+from app.config import Config
+from dateutil.relativedelta import relativedelta
+from googleapiclient.discovery import build
+from oauth2client.service_account import ServiceAccountCredentials
+
+SCOPES = [Config.GOOGLE_API_GA_SCOPE]
+KEY_PATH = Config.GOOGLE_API_GA_KEY_PATH
+VIEW_ID = Config.GOOGLE_API_GA_VIEW_ID
+
+
+def init_ga_reporting():
+    credentials = ServiceAccountCredentials.from_json_keyfile_name(
+        KEY_PATH,
+        SCOPES
+    )
+    analytics = build('analyticsreporting', 'v4', credentials=credentials)
+    return analytics
+
+
+def get_ga_1year_sessions(analytics):
+
+    start_date = datetime.now() - relativedelta(years=1)
+    formatted_start_date = start_date.strftime('%Y-%m-%d')
+
+    try:
+        report = analytics.reports().batchGet(
+            body={
+                "reportRequests": [{
+                    "viewId": VIEW_ID,
+                    "dateRanges": [{
+                        "startDate": formatted_start_date,
+                        "endDate": datetime.now().strftime('%Y-%m-%d')
+                    }],
+                    "metrics": [{"expression": "ga:sessions"}]
+                }]
+            }
+        ).execute()
+
+        if len(report["reports"]):
+            total = report["reports"][0]["data"]["totals"][0]["values"][0]
+            return int(total)
+
+    except:
+        return None

--- a/app/metrics/ga.py
+++ b/app/metrics/ga.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 
 from app.config import Config
@@ -11,12 +12,17 @@ VIEW_ID = Config.GOOGLE_API_GA_VIEW_ID
 
 
 def init_ga_reporting():
-    credentials = ServiceAccountCredentials.from_json_keyfile_name(
-        KEY_PATH,
-        SCOPE
-    )
-    analytics = build('analyticsreporting', 'v4', credentials=credentials)
-    return analytics
+    try:
+        credentials = ServiceAccountCredentials.from_json_keyfile_name(
+            KEY_PATH,
+            SCOPE
+        )
+        analytics = build('analyticsreporting', 'v4', credentials=credentials)
+        return analytics
+
+    except Exception as e:
+        logging.error('An error occured while instantiating the GA reporter.', e)
+        return None
 
 
 def get_ga_1year_sessions(analytics):

--- a/app/metrics/ga.py
+++ b/app/metrics/ga.py
@@ -5,7 +5,7 @@ from dateutil.relativedelta import relativedelta
 from googleapiclient.discovery import build
 from oauth2client.service_account import ServiceAccountCredentials
 
-SCOPES = [Config.GOOGLE_API_GA_SCOPE]
+SCOPE = Config.GOOGLE_API_GA_SCOPE
 KEY_PATH = Config.GOOGLE_API_GA_KEY_PATH
 VIEW_ID = Config.GOOGLE_API_GA_VIEW_ID
 
@@ -13,7 +13,7 @@ VIEW_ID = Config.GOOGLE_API_GA_VIEW_ID
 def init_ga_reporting():
     credentials = ServiceAccountCredentials.from_json_keyfile_name(
         KEY_PATH,
-        SCOPES
+        SCOPE
     )
     analytics = build('analyticsreporting', 'v4', credentials=credentials)
     return analytics

--- a/app/metrics/pennsieve.py
+++ b/app/metrics/pennsieve.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+import requests
+from app.config import Config
+from dateutil.relativedelta import relativedelta
+
+API_URL = Config.DISCOVER_API_HOST
+
+def get_download_count():
+
+    start_date = datetime.now() - relativedelta(years=1)
+    formatted_start_date = start_date.strftime('%Y-%m-%d')
+
+    params = {
+        "startDate": formatted_start_date,
+        "endDate": datetime.now().strftime('%Y-%m-%d')
+    }
+    req = requests.get(API_URL + '/metrics/dataset/downloads/summary', params=params)
+
+    if (req):
+        resp = req.json()
+
+        count = 0
+        for dataset in resp:
+            count += dataset["downloads"]
+
+        return count
+
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,7 @@ urllib3==1.26.4
 Werkzeug==0.16.0
 psycopg2-binary==2.8.6
 APScheduler==3.7.0
+google-api-python-client==2.52.0
+oauth2client==4.1.3
+algoliasearch==2.6.2
+contentful==1.13.1


### PR DESCRIPTION
This PR brings back the metrics API with the following changes:

* ALGOLIA_API_INDEX is now ALGOLIA_INDEX to match that one of ``sparc-app``
* The app does not crash when failing to create the different data provider clients (due to missing or wrong env vars)

### Important note for deployment
The execution of ``.profile`` was creating a JSON file with the wrong format, replacing the \n in the GAs private key by actual line breaks which caused the instantiation of the reporter to fail since the key was wrong. Trying escaping the backslash with another backslash ``\\n`` solved the problem on my side.

#### Testing
I manually tried to remove the environmental values for the different providers and checked that the app does not crash anymore, the rest would still work, and requesting a GET to ``/metrics`` will always give a response with the available ones.