### PR TITLE
Add script for collection of monthly user download stats

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,7 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 
 class Config(object):
-    PENNSIEVE_API_HOST = os.environ.get("PENNSIEVE_API_HOST")
+    PENNSIEVE_API_HOST = os.environ.get("PENNSIEVE_API_HOST", "https://api.pennsieve.io")
     PENNSIEVE_API_SECRET = os.environ.get("PENNSIEVE_API_SECRET", "local-secret-key")
     PENNSIEVE_API_TOKEN = os.environ.get("PENNSIEVE_API_TOKEN", "local-api-key")
     PENNSIEVE_EMBARGO_TEAM_ID = os.environ.get("PENNSIEVE_EMBARGO_TEAM_ID")

--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,7 @@ class Config(object):
     PENNSIEVE_API_SECRET = os.environ.get("PENNSIEVE_API_SECRET", "local-secret-key")
     PENNSIEVE_API_TOKEN = os.environ.get("PENNSIEVE_API_TOKEN", "local-api-key")
     PENNSIEVE_EMBARGO_TEAM_ID = os.environ.get("PENNSIEVE_EMBARGO_TEAM_ID")
+    PENNSIEVE_ORGANIZATION = os.environ.get("PENNSIEVE_ORGANIZATION")
     DATABASE_URL = os.environ.get('DATABASE_URL')
     DISCOVER_API_HOST = os.environ.get(
         "DISCOVER_API_HOST", "https://api.pennsieve.io/discover"
@@ -51,6 +52,7 @@ class Config(object):
     SCI_CRUNCH_INTERLEX_HOST = os.environ.get("SCI_CRUNCH_INTERLEX_HOST", "https://scicrunch.org/api/1/elastic/Interlex_pr")
     SCI_CRUNCH_SCIGRAPH_HOST = os.environ.get("SCI_CRUNCH_SCIGRAPH_HOST", "https://scicrunch.org/api/1/sparc-scigraph")
     SENDGRID_API_KEY =  os.environ.get("SENDGRID_API_KEY")
+    SENDGRID_MONTHLY_STATS_UNSUBSCRIBE_GROUP = os.environ.get("SENDGRID_MONTHLY_STATS_UNSUBSCRIBE_GROUP")
     README_API_KEY =  os.environ.get("README_API_KEY")
     # Metrics
     GOOGLE_API_GA_SCOPE = os.environ.get("GOOGLE_API_GA_SCOPE", "https://www.googleapis.com/auth/analytics.readonly")

--- a/app/main.py
+++ b/app/main.py
@@ -128,11 +128,13 @@ def connect_to_pennsieve():
 
 viewers_scheduler = BackgroundScheduler()
 metrics_scheduler = BackgroundScheduler()
-monthly_stats_email_scheduler = BackgroundScheduler()
 
-ms = MonthlyStats()
-monthly_stats_email_scheduler.start()
-monthly_stats_email_scheduler.add_job(ms.daily_run_check, 'interval', days=1)
+# Run monthly stats email schedule on production
+if Config.DEPLOY_ENV is 'production':
+    monthly_stats_email_scheduler = BackgroundScheduler()
+    ms = MonthlyStats()
+    monthly_stats_email_scheduler.start()
+    monthly_stats_email_scheduler.add_job(ms.daily_run_check, 'interval', days=1)
 
 @app.before_first_request
 def get_osparc_file_viewers():

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from app.metrics.pennsieve import get_download_count
 from app.metrics.contentful import init_cf_client, get_funded_projects_count
 from app.metrics.algolia import get_dataset_count, init_algolia_client
 from app.metrics.ga import init_ga_reporting, get_ga_1year_sessions
+from scripts.monthly_stats import MonthlyStats
 
 import boto3
 import json
@@ -127,7 +128,11 @@ def connect_to_pennsieve():
 
 viewers_scheduler = BackgroundScheduler()
 metrics_scheduler = BackgroundScheduler()
+monthly_stats_email_scheduler = BackgroundScheduler()
 
+ms = MonthlyStats()
+monthly_stats_email_scheduler.start()
+monthly_stats_email_scheduler.add_job(ms.daily_run_check, 'interval', days=1)
 
 @app.before_first_request
 def get_osparc_file_viewers():

--- a/app/metrics/pennsieve.py
+++ b/app/metrics/pennsieve.py
@@ -6,9 +6,9 @@ from dateutil.relativedelta import relativedelta
 
 API_URL = Config.DISCOVER_API_HOST
 
-def get_download_count():
+def get_download_count(time_delta=relativedelta(years=1)):
 
-    start_date = datetime.now() - relativedelta(years=1)
+    start_date = datetime.now() - time_delta
     formatted_start_date = start_date.strftime('%Y-%m-%d')
 
     params = {
@@ -25,5 +25,22 @@ def get_download_count():
             count += dataset["downloads"]
 
         return count
+
+    return None
+
+
+def get_pennseive_download_metrics(time_delta=relativedelta(years=1)):
+    start_date = datetime.now() - time_delta
+    formatted_start_date = start_date.strftime('%Y-%m-%d')
+
+    params = {
+        "startDate": formatted_start_date,
+        "endDate": datetime.now().strftime('%Y-%m-%d')
+    }
+    req = requests.get(API_URL + '/metrics/dataset/downloads/summary', params=params)
+
+    if (req):
+        resp = req.json()
+        return resp
 
     return None

--- a/scripts/email_sender.py
+++ b/scripts/email_sender.py
@@ -41,7 +41,9 @@ class EmailSender(object):
         self.charset = "UTF-8"
         self.ses_sender = Config.SES_SENDER
         self.ses_arn = Config.SES_ARN
-        self.unsubscribe_group = Config.SENDGRID_MONTHLY_STATS_UNSUBSCRIBE_GROUP
+        self.unsubscribe_group = 0  # Note that this must be an integer for use in "sendgrid.GoupId"
+        if Config.SENDGRID_MONTHLY_STATS_UNSUBSCRIBE_GROUP is not '':
+            self.unsubscribe_group = int(Config.SENDGRID_MONTHLY_STATS_UNSUBSCRIBE_GROUP)
 
     def send_email(self, name, email_address, message):
         body = name + "\n" + email_address + "\n" + message

--- a/scripts/monthly_downloads_html_template.py
+++ b/scripts/monthly_downloads_html_template.py
@@ -1,0 +1,30 @@
+html_start = \
+'<h1 style="color: #1a1489;" data-darkreader-inline-color="">Sparc Download Statistics</h1> \
+<p>This month, you have had downloads on the following datasets:</p> \
+<table style="border-collapse: collapse; width: 100%;" border="1"> \
+<tbody> \
+<tr> \
+<td style="width: 27.3912%;">Dataset ID</td> \
+<td style="width: 22.6088%;">Version</td> \
+<td style="width: 25%;">Origin</td> \
+<td style="width: 25%;">Downloads</td> \
+</tr>'
+
+
+
+html_end = '\
+</tbody> \
+</table>'
+
+def create_html_template(datasets_download_info):
+    html_string = html_start
+    for dataset in datasets_download_info:
+        html_string += f'<tr> \
+        <td style="width: 27.3912%;">{dataset["datasetId"]}</td> \
+        <td style="width: 22.6088%;">{dataset["version"]}</td> \
+        <td style="width: 25%;">{dataset["origin"]}</td> \
+        <td style="width: 25%;">{dataset["downloads"]}</td> \
+        </tr>'
+    html_string += html_end
+    return html_string
+

--- a/scripts/monthly_stats.py
+++ b/scripts/monthly_stats.py
@@ -6,7 +6,14 @@ from scripts.monthly_downloads_html_template import create_html_template
 from scripts.email_sender import EmailSender
 import requests
 import datetime
+import json
 from dateutil.relativedelta import relativedelta
+
+def remove_duplicates(d_array):
+    json_list = [json.dumps(d) for d in d_array]
+    json_set = set(json_list)
+    unique_list = [json.loads(d) for d in json_set]
+    return unique_list
 
 class MonthlyStats(object):
     def __init__(self, debug_mode=False, debug_email=''):
@@ -49,7 +56,7 @@ class MonthlyStats(object):
         for orcid_id in user_stats:
             if 'email' in user_stats[orcid_id].keys():
                 email_address = user_stats[orcid_id]['email']
-                email_body = create_html_template(user_stats[orcid_id]['datasets'])
+                email_body = create_html_template(remove_duplicates(user_stats[orcid_id]['datasets']))
                 r = self.send_email(email_address, email_body)
             responses.append(r)
         return responses

--- a/scripts/monthly_stats.py
+++ b/scripts/monthly_stats.py
@@ -19,6 +19,9 @@ class MonthlyStats(object):
         self.debug_email = debug_email
         self.debug_mode = debug_mode
 
+    # daily_run_check runs on a set day of the month. However, since we do nt want to send two emails to users if the
+    #       app restarts on the first day of the month, We assume an email has already been sent if the app has just
+    #       started and set a cooldown period of 24h. This ensures we pass the 1 day trigger for sending the emails
     def daily_run_check(self):
         now = datetime.datetime.now()
         if now.day == self.run_day:  # Check if current day is run day

--- a/scripts/monthly_stats.py
+++ b/scripts/monthly_stats.py
@@ -47,9 +47,10 @@ class MonthlyStats(object):
     def send_stats(self, user_stats):
         responses = []
         for orcid_id in user_stats:
-            email_address = user_stats[orcid_id]['email']
-            email_body = create_html_template(user_stats[orcid_id]['datasets'])
-            r = self.send_email(email_address, email_body)
+            if 'email' in user_stats[orcid_id].keys():
+                email_address = user_stats[orcid_id]['email']
+                email_body = create_html_template(user_stats[orcid_id]['datasets'])
+                r = self.send_email(email_address, email_body)
             responses.append(r)
         return responses
 

--- a/tests/test_monthly_stats.py
+++ b/tests/test_monthly_stats.py
@@ -3,6 +3,9 @@ from app.config import Config
 from scripts.monthly_stats import MonthlyStats
 from nose.tools import assert_true
 
+#  The email address below can be modified to check the emails are sending and look as expected
+#  (using any email you control is fine as long as it is not pushed to github)
+
 test_email_recipient = 'myname@domain.com'
 
 test_data = {

--- a/tests/test_monthly_stats.py
+++ b/tests/test_monthly_stats.py
@@ -53,16 +53,15 @@ def test_stats_generation():
     stats = ms.get_stats()
     assert_true(len(stats.keys()) > 0)
 
+# Note: unfortunately the sendgrid python client returns 202 regardless of whether the email was sent or not.
+#   There is also no body to see if the request is successful. Because of this all we will do is check for 202
+#   There may be more control calling the sendgrid api directly if we switch to it
 
 def test_email():  # Note that this will send an email to the test_"email_recipient" provided at the top of this doc
     responses = ms.send_stats(test_data)
-    if True in [r.status_code == 202 for r in responses]:
-        print('Uh-oh, we have hit the sendgrid max email limit!')
-    assert_true(False not in [r.status_code == 200 for r in responses])  # Check all responses were 200
+    assert_true(False not in [r.status_code == 202 for r in responses])  # Check all responses were 202
 
 
 def test_full_run():  # For each recipient, this will send an email to the test_email for each email that would have been sent to a user
     responses = ms.run()
-    if True in [r.status_code == 202 for r in responses]:
-        print('Uh-oh, we have hit the sendgrid max email limit!')
-    assert_true(False not in [r.status_code == 200 for r in responses])
+    assert_true(False not in [r.status_code == 202 for r in responses])

--- a/tests/test_monthly_stats.py
+++ b/tests/test_monthly_stats.py
@@ -1,0 +1,52 @@
+import requests
+from app.config import Config
+from scripts.monthly_stats import MonthlyStats
+from nose.tools import assert_true
+
+test_email_recipient = 'myname@domain.com'
+
+test_data = {
+    "0000-0002-3722-6351": {
+        "datasets": [
+            {
+                "datasetId": 230,
+                "version": 1,
+                "origin": "SPARC",
+                "downloads": 1
+            },
+            {
+                "datasetId": 225,
+                "version": 1,
+                "origin": "SPARC",
+                "downloads": 1
+            },
+            {
+                "datasetId": 141,
+                "version": 2,
+                "origin": "SPARC",
+                "downloads": 1
+            }
+        ],
+        "email": test_email_recipient
+    }
+}
+
+ms = MonthlyStats()
+
+def test_pennsieve_login():
+    key = ms.pennsieve_login()
+    r = requests.get(f"{Config.PENNSIEVE_API_HOST}/datasets",
+                     headers={"Authorization": f"Bearer {key}"})
+    assert_true(r.status_code == 200)
+
+def test_metrics_endpoint():
+    stats = ms.get_download_metrics_one_month()
+    assert_true(len(stats.keys()) > 0) # note this assumes there is at least one download a month
+
+def test_stats_generation():
+    stats = ms.get_stats()
+    assert_true(len(stats.keys()) > 0)
+
+def test_email(): # Note that this will send an email to the test_"email_recipient" provided at the top of this doc
+    response = ms.send_stats(test_data)
+    assert_true(response.status_code == 200)

--- a/tests/test_monthly_stats.py
+++ b/tests/test_monthly_stats.py
@@ -55,10 +55,14 @@ def test_stats_generation():
 
 
 def test_email():  # Note that this will send an email to the test_"email_recipient" provided at the top of this doc
-    response = ms.send_stats(test_data)
-    assert_true(response.status_code == 200)
+    responses = ms.send_stats(test_data)
+    if True in [r.status_code == 202 for r in responses]:
+        print('Uh-oh, we have hit the sendgrid max email limit!')
+    assert_true(False not in [r.status_code == 200 for r in responses])  # Check all responses were 200
 
 
 def test_full_run():  # For each recipient, this will send an email to the test_email for each email that would have been sent to a user
     responses = ms.run()
-    assert_true(False not in [r.status_code == 200 for r in responses])  # Check all responses were 200
+    if True in [r.status_code == 202 for r in responses]:
+        print('Uh-oh, we have hit the sendgrid max email limit!')
+    assert_true(False not in [r.status_code == 200 for r in responses])

--- a/tests/test_monthly_stats.py
+++ b/tests/test_monthly_stats.py
@@ -31,7 +31,8 @@ test_data = {
     }
 }
 
-ms = MonthlyStats()
+ms = MonthlyStats(debug_mode=True, debug_email=test_email_recipient)
+
 
 def test_pennsieve_login():
     key = ms.pennsieve_login()
@@ -39,14 +40,22 @@ def test_pennsieve_login():
                      headers={"Authorization": f"Bearer {key}"})
     assert_true(r.status_code == 200)
 
+
 def test_metrics_endpoint():
     stats = ms.get_download_metrics_one_month()
-    assert_true(len(stats.keys()) > 0) # note this assumes there is at least one download a month
+    assert_true(len(stats) > 0)  # note this assumes there is at least one download a month
+
 
 def test_stats_generation():
     stats = ms.get_stats()
     assert_true(len(stats.keys()) > 0)
 
-def test_email(): # Note that this will send an email to the test_"email_recipient" provided at the top of this doc
+
+def test_email():  # Note that this will send an email to the test_"email_recipient" provided at the top of this doc
     response = ms.send_stats(test_data)
     assert_true(response.status_code == 200)
+
+
+def test_full_run():  # For each recipient, this will send an email to the test_email for each email that would have been sent to a user
+    responses = ms.run()
+    assert_true(False not in [r.status_code == 200 for r in responses])  # Check all responses were 200


### PR DESCRIPTION
# Description

This pr is for the ticket:

#### [Notify dataset owner about dataset access instances/downloads](https://www.wrike.com/open.htm?id=473521309)

### How to test
Note that since this is a scheduled function, the best way to test it is to use a test email address and running the tests [here](https://github.com/Tehsurfer/sparc-api/blob/monthly-stats/tests/test_monthly_stats.py)

### How it works
#### Schedule
[`apscheduler`](https://apscheduler.readthedocs.io/en/3.x/userguide.html) is used in combination with a server uptime check to ensure that one email is sent a month. However this email can still be missed if the app is not online during the send time period

#### Send day logic
`apschedule` is set to run the daily_run_check every day
https://github.com/Tehsurfer/sparc-api/blob/f75b949643ad1739a523e938f2a963b9b564c04c/app/main.py#L135

And `daily_run_check` runs on a set day of the month. However, since we do not want to send two emails to users if the app restarts on the first day of the month, We assume an email has already been sent if the app has just started and set a cooldown period of 24h. This ensures we have a 1st day of the month trigger for sending the emails

This can be viewed here:
https://github.com/Tehsurfer/sparc-api/blob/f75b949643ad1739a523e938f2a963b9b564c04c/scripts/monthly_stats.py#L25

#### Download statistic creation
The following path is taken to create download stats for each user:

1. [Request one months download metrics](https://github.com/Tehsurfer/sparc-api/blob/f75b949643ad1739a523e938f2a963b9b564c04c/scripts/monthly_stats.py#L57)
2. [Request dataset details for datasets with downloads](https://github.com/Tehsurfer/sparc-api/blob/f75b949643ad1739a523e938f2a963b9b564c04c/scripts/monthly_stats.py#L100) (this is used for retrieving user's orcid ids who contributed to the dataset
3. [Request emails for users who have datasets that have been downloaded](https://github.com/Tehsurfer/sparc-api/blob/f75b949643ad1739a523e938f2a963b9b564c04c/scripts/monthly_stats.py#L85) (note that we use orcid ids for this)
4. Step through the orcid ids and send the stats to each user.

### Config set up

The following config variables are needed to run this. Please DM me if need any:

```
PENNSIEVE_API_SECRET = os.environ.get("PENNSIEVE_API_SECRET", "local-secret-key")
PENNSIEVE_API_TOKEN = os.environ.get("PENNSIEVE_API_TOKEN", "local-api-key")
PENNSIEVE_ORGANIZATION = os.environ.get("PENNSIEVE_ORGANIZATION", "N:organization:618e8dd9-f8d2-4dc4-9abb-c6aaab2e78a0")
SES_SENDER = os.environ.get("SES_SENDER", "yoursendgridemail@gmail.com'")
SENDGRID_API_KEY =  os.environ.get("SENDGRID_API_KEY")
SENDGRID_MONTHLY_STATS_UNSUBSCRIBE_GROUP = os.environ.get("SENDGRID_MONTHLY_STATS_UNSUBSCRIBE_GROUP", "00000000")
```

### What is still needed? 

Note that we still need to set up a sendgrid subscribe group for this

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Tested using my own sendgrid account and subscribe group.

All tests needed for this can be found here:
https://github.com/Tehsurfer/sparc-api/blob/monthly-stats/scripts/monthly_stats.py

Remember the config vars listed above are needed to run this

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
