### PR TITLE
Publish entries after update

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -145,14 +145,14 @@ if Config.DEPLOY_ENV == 'production':
     monthly_stats_email_scheduler.start()
     monthly_stats_email_scheduler.add_job(ms.daily_run_check, 'interval', days=1)
 
-# Run update contentful entries scheduler on staging so that it updates all the entries, not just published ones
+# Only need to run the update contentful entries scheduler on one environment, so dev was chosen to keep prod more responsive
 if Config.DEPLOY_ENV == 'development':
     update_contentful_event_entries_scheduler = BackgroundScheduler()
     if not update_contentful_event_entries_scheduler.running:
         logging.info('Starting scheduler for updating contentful event entries')
         update_contentful_event_entries_scheduler.start()
     # Update the contentful entries on deploy and then daily at 2 AM EST
-    update_contentful_event_entries_scheduler.add_job(update_event_entries, 'date')
+    update_contentful_event_entries_scheduler.add_job(update_event_entries, 'cron', hour=2, timezone='US/Eastern')
 
 @app.before_first_request
 def get_osparc_file_viewers():

--- a/app/main.py
+++ b/app/main.py
@@ -151,7 +151,7 @@ if Config.DEPLOY_ENV == 'development':
     if not update_contentful_event_entries_scheduler.running:
         logging.info('Starting scheduler for updating contentful event entries')
         update_contentful_event_entries_scheduler.start()
-    # Update the contentful entries on deploy and then daily at 4 AM EST
+    # Update the contentful entries on deploy and then daily at 2 AM EST
     update_contentful_event_entries_scheduler.add_job(update_event_entries, 'date')
 
 @app.before_first_request

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -96,3 +96,7 @@ def publish_entry(id, version):
         headers=hed,
         url=url
     )
+
+#def entry_is_updated(entry):
+#    return 
+

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -3,6 +3,7 @@ from app.config import Config
 import contentful
 import contentful_management
 import requests
+import asyncio
 
 #CDA is used for reading content, while CMA is used for updating content
 CDA_API_HOST = Config.CTF_CDA_API_HOST
@@ -71,11 +72,12 @@ async def update_entry_using_json_response(content_type, id, data):
         'X-Contentful-Content-Type': str(content_type),
         'X-Contentful-Version': str(version)
     }
-    return requests.put(
+    task = asyncio.create_task(requests.put(
         headers=hed,
         url=url,
         json=data
-    )
+    ))
+    await task
 
 def get_entry_version(id):
     client = init_cf_cma_client()

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -71,7 +71,7 @@ async def update_entry_using_json_response(content_type, id, data):
         'X-Contentful-Content-Type': str(content_type),
         'X-Contentful-Version': str(version)
     }
-    await requests.put(
+    return await requests.put(
         headers=hed,
         url=url,
         json=data

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -66,8 +66,8 @@ def update_entry_using_json_response(content_type, id, version, data):
         'Authorization': 'Bearer ' + Config.CTF_CMA_ACCESS_TOKEN,
         'Content-Type': 'application/vnd.contentful.management.v1+json',
         'Accept': 'application/json',
-        'X-Contentful-Content-Type': content_type,
-        'X-Contentful-Version': version
+        'X-Contentful-Content-Type': str(content_type),
+        'X-Contentful-Version': str(version)
     }
     return requests.put(
         headers=hed,

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -60,7 +60,7 @@ def get_all_published_entries(content_type_id):
 
 # Since get_all_published_entries has to use direct HTTP endpoint its response is in a different format than when using the client to get_all_entries
 # Therefore, in order to update an entry with that kind of response we must use this method instead of the client SDK update method
-async def update_entry_using_json_response(content_type, id, data):
+def update_entry_using_json_response(content_type, id, data):
     version = get_entry_version(id)
 
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}'
@@ -71,7 +71,7 @@ async def update_entry_using_json_response(content_type, id, data):
         'X-Contentful-Content-Type': str(content_type),
         'X-Contentful-Version': str(version)
     }
-    return await requests.put(
+    return requests.put(
         headers=hed,
         url=url,
         json=data

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -60,10 +60,15 @@ def get_client_entry(id):
     client = init_cf_cma_client()
     return client.entries(Config.CTF_SPACE_ID, 'master').find(id)
 
+def get_entry(id):
+  url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}?access_token={Config.CTF_CMA_ACCESS_TOKEN}'
+    response = requests.get(url=url)
+    return response.json()
+
 # Since get_all_published_entries has to use direct HTTP endpoint its response is in a different format than when using the client to get_all_entries
 # Therefore, in order to update an entry with that kind of response we must use this method instead of the client SDK update method
 def update_entry_using_json_response(content_type, id, data):
-    version = get_client_entry(id).sys['version']
+    version = get_entry(id)['sys']['version']
 
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}'
     hed = {

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -3,6 +3,7 @@ from app.config import Config
 import contentful
 import contentful_management
 import requests
+import json
 
 #CDA is used for reading content, while CMA is used for updating content
 CDA_API_HOST = Config.CTF_CDA_API_HOST
@@ -54,6 +55,4 @@ def get_all_entries(content_type_id):
 def get_all_published_entries(content_type_id):
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/public/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
     response = requests.get(url)
-    json_response = response.json()
-    return json_response['items']
-    
+    return json.loads(response)['items']

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -61,8 +61,9 @@ def get_all_published_entries(content_type_id):
 
 # Since get_all_published_entries has to use direct HTTP endpoint its response is in a different format than when using the client to get_all_entries
 # Therefore, in order to update an entry with that kind of response we must use this method instead of the client SDK update method
-async def update_entry_using_json_response(content_type, id, data):
+def update_entry_using_json_response(content_type, id, data):
     version = get_entry_version(id)
+    print("GOT VERSION")
 
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}'
     hed = {
@@ -72,12 +73,12 @@ async def update_entry_using_json_response(content_type, id, data):
         'X-Contentful-Content-Type': str(content_type),
         'X-Contentful-Version': str(version)
     }
-    await requests.put(
+    print("ABOUT TO SEND OUT HTTP PUT FOR UPDATE")
+    return requests.put(
         headers=hed,
         url=url,
         json=data
     )
-    return
 
 def get_entry_version(id):
     client = init_cf_cma_client()

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -53,7 +53,25 @@ def get_all_entries(content_type_id):
   return content_type.entries().all()
 
 def get_all_published_entries(content_type_id):
+    # client SDK currently has no corresponding method for getting all published so we have to access directly via an http GET request
+    # https://www.contentful.com/developers/docs/references/content-management-api/#/reference/entries/published-entries-collection/get-all-published-entries-of-a-space/console/python
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/public/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
     response = requests.get(url)
-    print(f"RESPONSE = {json.loads(response)}")
     return response.json()
+
+# Since get_all_published_entries has to use direct HTTP endpoint its response is in a different format than when using the client to get_all_entries
+# Therefore, in order to update an entry with that kind of response we must use this method instead of the client SDK update method
+def update_entry_using_json_response(content_type, id, version, data):
+    url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}'
+    hed = {
+        'Authorization': 'Bearer ' + Config.CTF_CMA_ACCESS_TOKEN,
+        'Content-Type': 'application/vnd.contentful.management.v1+json',
+        'Accept': 'application/json',
+        'X-Contentful-Content-Type': content_type,
+        'X-Contentful-Version': version
+    }
+    return requests.put(
+        headers=hed,
+        url=url,
+        json=data
+    )

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -47,11 +47,14 @@ def get_homepage_response(client):
   return response.fields()
 
 def get_all_entries(content_type_id):
-  client = init_cf_cma_client()
-  content_type = client.content_types(SPACE_ID, 'master').find(content_type_id)
-  return content_type.entries().all()
+    url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
+    response = requests.get(url=url)
+    return response.json()['items']
+  #client = init_cf_cma_client()
+  #content_type = client.content_types(SPACE_ID, 'master').find(content_type_id)
+  #return content_type.entries().all()
 
-def get_entry(id):
+def get_client_entry(id):
     client = init_cf_cma_client()
     return client.entries(Config.CTF_SPACE_ID, 'master').find(id)
 
@@ -65,7 +68,7 @@ def get_all_published_entries(content_type_id):
 # Since get_all_published_entries has to use direct HTTP endpoint its response is in a different format than when using the client to get_all_entries
 # Therefore, in order to update an entry with that kind of response we must use this method instead of the client SDK update method
 def update_entry_using_json_response(content_type, id, data):
-    version = get_entry(id).sys['version']
+    version = get_client_entry(id).sys['version']
 
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}'
     hed = {

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -3,7 +3,6 @@ from app.config import Config
 import contentful
 import contentful_management
 import requests
-import asyncio
 
 #CDA is used for reading content, while CMA is used for updating content
 CDA_API_HOST = Config.CTF_CDA_API_HOST

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -55,10 +55,6 @@ def get_all_published_entries(content_type_id):
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/public/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
     response = requests.get(url)
     return response.json()['items']
-    
-def get_client_entry(id):
-    client = init_cf_cma_client()
-    return client.entries(Config.CTF_SPACE_ID, 'master').find(id)
 
 def get_entry(id):
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}?access_token={Config.CTF_CMA_ACCESS_TOKEN}'

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -55,5 +55,5 @@ def get_all_entries(content_type_id):
 def get_all_published_entries(content_type_id):
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/public/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
     response = requests.get(url)
-    print(f"RESPONSE = {response.read()}")
+    print(f"RESPONSE = {json.loads(response)}")
     return response.json()

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -55,4 +55,4 @@ def get_all_entries(content_type_id):
 def get_all_published_entries(content_type_id):
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/public/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
     response = requests.get(url)
-    return json.loads(response.json())['items']
+    return json.loads(response["items"].read())

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -55,4 +55,5 @@ def get_all_entries(content_type_id):
 def get_all_published_entries(content_type_id):
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/public/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
     response = requests.get(url)
-    return json.loads(response["items"].read())
+    print(f"RESPONSE = {response.read()}")
+    return response.json()

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -92,7 +92,3 @@ def publish_entry(id, version):
         headers=hed,
         url=url
     )
-
-#def entry_is_updated(entry):
-#    return 
-

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -3,7 +3,6 @@ from app.config import Config
 import contentful
 import contentful_management
 import requests
-import json
 
 #CDA is used for reading content, while CMA is used for updating content
 CDA_API_HOST = Config.CTF_CDA_API_HOST
@@ -57,7 +56,7 @@ def get_all_published_entries(content_type_id):
     # https://www.contentful.com/developers/docs/references/content-management-api/#/reference/entries/published-entries-collection/get-all-published-entries-of-a-space/console/python
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/public/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
     response = requests.get(url)
-    return response.json()
+    return response.json()['items']
 
 # Since get_all_published_entries has to use direct HTTP endpoint its response is in a different format than when using the client to get_all_entries
 # Therefore, in order to update an entry with that kind of response we must use this method instead of the client SDK update method

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -72,12 +72,12 @@ async def update_entry_using_json_response(content_type, id, data):
         'X-Contentful-Content-Type': str(content_type),
         'X-Contentful-Version': str(version)
     }
-    task = asyncio.create_task(requests.put(
+    await requests.put(
         headers=hed,
         url=url,
         json=data
-    ))
-    await task
+    )
+    return
 
 def get_entry_version(id):
     client = init_cf_cma_client()

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -60,7 +60,9 @@ def get_all_published_entries(content_type_id):
 
 # Since get_all_published_entries has to use direct HTTP endpoint its response is in a different format than when using the client to get_all_entries
 # Therefore, in order to update an entry with that kind of response we must use this method instead of the client SDK update method
-def update_entry_using_json_response(content_type, id, version, data):
+def update_entry_using_json_response(content_type, id, data):
+    version = get_entry_version(id)
+
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}'
     hed = {
         'Authorization': 'Bearer ' + Config.CTF_CMA_ACCESS_TOKEN,
@@ -74,3 +76,8 @@ def update_entry_using_json_response(content_type, id, version, data):
         url=url,
         json=data
     )
+
+def get_entry_version(id):
+    client = init_cf_cma_client()
+    entry = client.entries(Config.CTF_SPACE_ID, 'master').find(id)
+    return entry.sys['version']

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -60,7 +60,7 @@ def get_all_published_entries(content_type_id):
 
 # Since get_all_published_entries has to use direct HTTP endpoint its response is in a different format than when using the client to get_all_entries
 # Therefore, in order to update an entry with that kind of response we must use this method instead of the client SDK update method
-def update_entry_using_json_response(content_type, id, data):
+async def update_entry_using_json_response(content_type, id, data):
     version = get_entry_version(id)
 
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}'
@@ -71,7 +71,7 @@ def update_entry_using_json_response(content_type, id, data):
         'X-Contentful-Content-Type': str(content_type),
         'X-Contentful-Version': str(version)
     }
-    return requests.put(
+    await requests.put(
         headers=hed,
         url=url,
         json=data

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -51,6 +51,10 @@ def get_all_entries(content_type_id):
   content_type = client.content_types(SPACE_ID, 'master').find(content_type_id)
   return content_type.entries().all()
 
+def get_entry(id):
+    client = init_cf_cma_client()
+    return client.entries(Config.CTF_SPACE_ID, 'master').find(id)
+
 def get_all_published_entries(content_type_id):
     # client SDK currently has no corresponding method for getting all published so we have to access directly via an http GET request
     # https://www.contentful.com/developers/docs/references/content-management-api/#/reference/entries/published-entries-collection/get-all-published-entries-of-a-space/console/python
@@ -61,7 +65,7 @@ def get_all_published_entries(content_type_id):
 # Since get_all_published_entries has to use direct HTTP endpoint its response is in a different format than when using the client to get_all_entries
 # Therefore, in order to update an entry with that kind of response we must use this method instead of the client SDK update method
 def update_entry_using_json_response(content_type, id, data):
-    version = get_entry_version(id)
+    version = get_entry(id).sys['version']
     print("GOT VERSION")
 
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}'
@@ -78,8 +82,3 @@ def update_entry_using_json_response(content_type, id, data):
         url=url,
         json=data
     )
-
-def get_entry_version(id):
-    client = init_cf_cma_client()
-    entry = client.entries(Config.CTF_SPACE_ID, 'master').find(id)
-    return entry.sys['version']

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -60,7 +60,7 @@ def get_all_published_entries(content_type_id):
 
 # Since get_all_published_entries has to use direct HTTP endpoint its response is in a different format than when using the client to get_all_entries
 # Therefore, in order to update an entry with that kind of response we must use this method instead of the client SDK update method
-def update_entry_using_json_response(content_type, id, data):
+async def update_entry_using_json_response(content_type, id, data):
     version = get_entry_version(id)
 
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}'
@@ -71,7 +71,7 @@ def update_entry_using_json_response(content_type, id, data):
         'X-Contentful-Content-Type': str(content_type),
         'X-Contentful-Version': str(version)
     }
-    return requests.put(
+    return await requests.put(
         headers=hed,
         url=url,
         json=data

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -50,7 +50,7 @@ def get_all_entries(content_type_id):
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
     response = requests.get(url=url)
     return response.json()['items']
-    
+
 def get_all_published_entries(content_type_id):
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/public/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
     response = requests.get(url)
@@ -61,7 +61,7 @@ def get_client_entry(id):
     return client.entries(Config.CTF_SPACE_ID, 'master').find(id)
 
 def get_entry(id):
-  url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}?access_token={Config.CTF_CMA_ACCESS_TOKEN}'
+    url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}?access_token={Config.CTF_CMA_ACCESS_TOKEN}'
     response = requests.get(url=url)
     return response.json()
 

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -50,20 +50,15 @@ def get_all_entries(content_type_id):
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
     response = requests.get(url=url)
     return response.json()['items']
-  #client = init_cf_cma_client()
-  #content_type = client.content_types(SPACE_ID, 'master').find(content_type_id)
-  #return content_type.entries().all()
-
-def get_client_entry(id):
-    client = init_cf_cma_client()
-    return client.entries(Config.CTF_SPACE_ID, 'master').find(id)
-
+    
 def get_all_published_entries(content_type_id):
-    # client SDK currently has no corresponding method for getting all published so we have to access directly via an http GET request
-    # https://www.contentful.com/developers/docs/references/content-management-api/#/reference/entries/published-entries-collection/get-all-published-entries-of-a-space/console/python
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/public/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
     response = requests.get(url)
     return response.json()['items']
+    
+def get_client_entry(id):
+    client = init_cf_cma_client()
+    return client.entries(Config.CTF_SPACE_ID, 'master').find(id)
 
 # Since get_all_published_entries has to use direct HTTP endpoint its response is in a different format than when using the client to get_all_entries
 # Therefore, in order to update an entry with that kind of response we must use this method instead of the client SDK update method

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -55,4 +55,4 @@ def get_all_entries(content_type_id):
 def get_all_published_entries(content_type_id):
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/public/entries?access_token={Config.CTF_CMA_ACCESS_TOKEN}&content_type={content_type_id}'
     response = requests.get(url)
-    return json.loads(response)['items']
+    return json.loads(response.json())['items']

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -79,3 +79,15 @@ def update_entry_using_json_response(content_type, id, data):
         url=url,
         json=data
     )
+
+def publish_entry(id, version):
+    url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}/published'
+    hed = {
+        'Authorization': 'Bearer ' + Config.CTF_CMA_ACCESS_TOKEN,
+        'X-Contentful-Version': str(version)
+    }
+    
+    return requests.put(
+        headers=hed,
+        url=url
+    )

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -66,7 +66,6 @@ def get_all_published_entries(content_type_id):
 # Therefore, in order to update an entry with that kind of response we must use this method instead of the client SDK update method
 def update_entry_using_json_response(content_type, id, data):
     version = get_entry(id).sys['version']
-    print("GOT VERSION")
 
     url = f'https://{Config.CTF_CMA_API_HOST}/spaces/{Config.CTF_SPACE_ID}/environments/master/entries/{id}'
     hed = {
@@ -76,7 +75,7 @@ def update_entry_using_json_response(content_type, id, data):
         'X-Contentful-Content-Type': str(content_type),
         'X-Contentful-Version': str(version)
     }
-    print("ABOUT TO SEND OUT HTTP PUT FOR UPDATE")
+    
     return requests.put(
         headers=hed,
         url=url,

--- a/app/metrics/contentful.py
+++ b/app/metrics/contentful.py
@@ -71,7 +71,7 @@ async def update_entry_using_json_response(content_type, id, data):
         'X-Contentful-Content-Type': str(content_type),
         'X-Contentful-Version': str(version)
     }
-    return await requests.put(
+    return requests.put(
         headers=hed,
         url=url,
         json=data

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -10,7 +10,6 @@ def update_event_entries():
         published_event_id = published_event['sys']['id']
         published_event_id_to_fields_mapping[published_event_id] = published_event
     now = datetime.now()
-    print("NOW = ", now)
     for entry in all_event_entries:
         original_fields_dict = entry.fields()
         if 'start_date' in original_fields_dict and 'upcoming_sort_order' in original_fields_dict and entry.sys['id']:
@@ -41,8 +40,8 @@ def update_event_entries():
                 response = update_entry_using_json_response('event', entry_id, updated_state)
                 print(f"UPDATE RAN WITH RESPONSE = {response.json()}")
                 print("ABOUT TO CALL SAVE")
-                #entry.save()
-                #entry.publish()
+                print("SAVE CALLED")
+                entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -34,7 +34,7 @@ def update_event_entries():
                 entry_id = entry.sys['id']
                 # if entry has changes that are not yet published then we want to publish only the already published state
                 published_fields_state = published_event_id_to_fields_mapping[entry_id]['fields']
-                published_fields_state['upcomingSortOrder'] = upcoming_sort_order
+                published_fields_state['upcomingSortOrder']['en-US'] = upcoming_sort_order
                 if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
                   print(f"Original State = {original_fields_dict}")
                   print(f"Published State = {published_fields_state}")

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -41,6 +41,7 @@ def update_event_entries():
                 }
                 updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
                 publish_entry(entry_id, updated_entry['sys']['version'])
+                print(f"{original_fields_dict['title']}")
             if entry_had_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there
                 original_state = {

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -35,9 +35,9 @@ def update_event_entries():
                 if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
                   print(f"{original_fields_dict['title']} State = {published_fields_state}")
                 # update and publish it with the values that were already published (in addition to the updated sort order)
-                #entry.update(published_fields_state)
-                #entry.save()
-                #entry.publish()
+                entry.update(published_fields_state)
+                entry.save()
+                entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -38,8 +38,11 @@ async def update_event_entries():
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
                 print("ABOUT TO RUN UPDATE")
-                asyncio.run(update_entry_using_json_response('event', entry_id, updated_state))
-                print("UPDATE RAN")
+                response = update_entry_using_json_response('event', entry_id, updated_state)
+                print(f"UPDATE RAN WITH RESPONSE = {response.json()}")
+                print("ABOUT TO CALL SAVE")
+                entry.save()
+                #entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -39,13 +39,14 @@ def update_event_entries():
                     'fields': published_fields_state,
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
-                updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
-                publish_entry(entry_id, updated_entry['sys']['version'])
+                #updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
+                #publish_entry(entry_id, updated_entry['sys']['version'])
             if entry_had_existing_changes:
+                print(f"{original_fields_dict['title']} had existing changes")
                 # after publishing, save it again with the pre-existing changes that were already there
                 original_state = {
                     'fields': original_fields_dict,
                     'metadata': original_metadata_dict
                 }
-                update_entry_using_json_response('event', entry_id, original_state).json()
+                #update_entry_using_json_response('event', entry_id, original_state).json()
     print("UPDATE COMPLETE!")

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -1,5 +1,6 @@
 from app.metrics.contentful import get_all_entries, get_all_published_entries, update_entry_using_json_response
 from datetime import datetime, timezone
+import asyncio
 
 def update_event_entries():
     all_event_entries = get_all_entries("event")
@@ -36,9 +37,8 @@ def update_event_entries():
                     'fields': published_fields_state,
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
-                updated_entry = update_entry_using_json_response('event', entry_id, updated_state)
-                print(f"ENTRY UPDATED = {updated_entry}")
-                entry.publish()
+                update_entry_task = asyncio.create_task(update_entry_using_json_response('event', entry_id, updated_state))
+                update_entry_task.add_done_callback(entry.publish())
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -9,6 +9,8 @@ def update_event_entries():
     published_event_id_to_fields_mapping = {}
     for published_event in all_published_event_entries:
         published_event_id = published_event['sys']['id']
+        if published_event_id == '69F1dOYJ3sqsL8pI55KTrk':
+            print(f"PUBLISHED EVENT = {published_event}")
         published_event_id_to_fields_mapping[published_event_id] = published_event
     now = datetime.now()
     for entry in all_event_entries:

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -1,7 +1,7 @@
 from app.metrics.contentful import get_all_entries, get_all_published_entries, update_entry_using_json_response
 from datetime import datetime, timezone
 
-async def update_event_entries():
+def update_event_entries():
     all_event_entries = get_all_entries("event")
     all_published_event_entries = get_all_published_entries("event")
     # Create dict with id's as the key so we do not have to iterate through each time we publish an entry

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -11,6 +11,7 @@ async def update_event_entries():
         published_event_id = published_event['sys']['id']
         published_event_id_to_fields_mapping[published_event_id] = published_event
     now = datetime.now()
+    print("NOW = ", now)
     for entry in all_event_entries:
         original_fields_dict = entry.fields()
         if 'start_date' in original_fields_dict and 'upcoming_sort_order' in original_fields_dict and entry.sys['id']:

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -21,8 +21,9 @@ def update_event_entries():
             entry_is_published = False 
             if 'publishedAt' in entry['sys']:
                 entry_is_published = True
-                entry_updated_at = datetime.strptime(datetime.fromisoformat(entry['sys']['updatedAt']).astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S.%f'), '%Y-%m-%d %H:%M:%S.%f')
-                entry_published_at = datetime.strptime(datetime.fromisoformat(entry['sys']['publishedAt']).astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S.%f'), '%Y-%m-%d %H:%M:%S.%f')
+                # convert UTC time strings into datetime objects
+                entry_updated_at = datetime.strptime(entry['sys']['updatedAt'], '%Y-%m-%dT%H:%M:%S.%fZ')
+                entry_published_at = datetime.strptime(entry['sys']['publishedAt'], '%Y-%m-%dT%H:%M:%S.%fZ')
                 if entry_updated_at - entry_published_at > 0:
                     entry_had_existing_changes = True
             

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -34,7 +34,7 @@ def update_event_entries():
                 entry_id = entry.sys['id']
                 # if entry has changes that are not yet published then we want to publish only the already published state
                 published_fields_state = published_event_id_to_fields_mapping[entry_id]['fields']
-                published_version = published_event_id_to_fields_mapping[entry_id]['sys']['version']
+                published_version = published_event_id_to_fields_mapping[entry_id]['sys']['publishedVersion']
                 published_fields_state['upcomingSortOrder'] = upcoming_sort_order
                 if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
                   print(f"Original State = {original_fields_dict}")

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -13,12 +13,12 @@ def update_event_entries():
     for entry in all_event_entries:
         original_fields_dict = entry['fields']
         original_metadata_dict = entry['metadata']
-        if 'start_date' in original_fields_dict and 'upcoming_sort_order' in original_fields_dict and entry['sys']['id']:
+        if 'startDate' in original_fields_dict and 'upcomingSortOrder' in original_fields_dict and entry['sys']['id']:
             entry_id = entry['sys']['id']
             client_entry = get_client_entry(entry_id)
             entry_had_existing_changes = client_entry.is_updated
             entry_is_published = client_entry.is_published
-            start_date = original_fields_dict['start_date']['en-US']
+            start_date = original_fields_dict['startDate']['en-US']
 
             # convert from ISO time format provided by contentful in UTC timezone to naive offset datetime object
             start_date_datetime = datetime.strptime(datetime.fromisoformat(start_date).astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S.%f'), '%Y-%m-%d %H:%M:%S.%f')
@@ -31,7 +31,7 @@ def update_event_entries():
                 upcoming_sort_order = 1/time_from_event_in_days
             if time_from_event_in_days < 0:
                 upcoming_sort_order = time_from_event_in_days
-            original_fields_dict['upcoming_sort_order']['en-US'] = upcoming_sort_order
+            original_fields_dict['upcomingSortOrder']['en-US'] = upcoming_sort_order
 
             if entry_is_published:
                 # if entry has changes that are not yet published then we want to publish only the already published state

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -37,9 +37,7 @@ async def update_event_entries():
                     'fields': published_fields_state,
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
-                update_entry_task = asyncio.create_task(update_entry_using_json_response('event', entry_id, updated_state))
-                update_entry_task.add_done_callback(entry.publish())
-                await update_entry_task
+                asyncio.run(update_entry_using_json_response('event', entry_id, updated_state))
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -17,10 +17,8 @@ def update_event_entries():
             client_entry = get_client_entry(entry_id)
             #entry_had_existing_changes = entry_is_updated(entry)
             entry_had_existing_changes = client_entry.is_updated
-            if entry_id == "6jTaWeILQyXg6e8cNwVujM":
-                print(f"Updated entry = {entry}")
-            if entry_id == "cfZahAKcq6SO4Sv2r77X9":
-                print(f"Un-updated entry = {entry}")
+            if entry_id == "2uumvOZ3blED0zQ0Vb65LS":
+                print(f"Draft entry = {entry}")
             entry_is_published = client_entry.is_published
             start_date = original_fields_dict['startDate']['en-US']
 

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -38,8 +38,6 @@ def update_event_entries():
                 }
                 updated_entry = update_entry_using_json_response('event', entry_id, updated_state)
                 print(f"ENTRY UPDATED = {updated_entry}")
-                entry.save()
-                print(f"SAVE CALLED")
                 entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -44,6 +44,7 @@ def update_event_entries():
                       'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                   }
                   update_entry_using_json_response('event', entry_id, published_version, updated_state)
+                  entry.save()
                 #entry.update(published_fields_state)
                 #entry.save()
                 #entry.publish()

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -1,14 +1,15 @@
-from app.metrics.contentful import get_all_entries, get_all_published_entries
+from app.metrics.contentful import get_all_entries, get_all_published_entries, update_entry_using_json_response
 from datetime import datetime, timezone
 
 def update_event_entries():
     all_event_entries = get_all_entries("event")
     all_published_event_entries = get_all_published_entries("event")
     # Create dict with id's as the key so we do not have to iterate through each time we publish an entry
+    # We must also keep track of the corresponding version since the update method needs this 
     published_event_id_to_fields_mapping = {}
     for published_event in all_published_event_entries:
         published_event_id = published_event['sys']['id']
-        published_event_id_to_fields_mapping[published_event_id] = published_event['fields']
+        published_event_id_to_fields_mapping[published_event_id] = published_event
     now = datetime.now()
     for entry in all_event_entries:
         original_fields_dict = entry.fields()
@@ -25,17 +26,22 @@ def update_event_entries():
                 upcoming_sort_order = 1/time_from_event_in_days
             if time_from_event_in_days < 0:
                 upcoming_sort_order = time_from_event_in_days
-            original_fields_dict['upcomingSortOrder'] = upcoming_sort_order
+            original_fields_dict['upcoming_sort_order'] = upcoming_sort_order
             entry_has_pre_existing_changes = entry.is_updated
             if entry.is_published:
                 entry_id = entry.sys['id']
                 # if entry has changes that are not yet published then we want to publish only the already published state
-                published_fields_state = published_event_id_to_fields_mapping[entry_id]
+                published_fields_state = published_event_id_to_fields_mapping[entry_id]['fields']
+                published_version = published_event_id_to_fields_mapping[entry_id]['sys']['version']
                 published_fields_state['upcomingSortOrder'] = upcoming_sort_order
                 if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
                   print(f"Original State = {original_fields_dict}")
                   print(f"Published State = {published_fields_state}")
-                # update and publish it with the values that were already published (in addition to the updated sort order)
+                  updated_state = {
+                      'fields': published_fields_state,
+                      'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
+                  }
+                  update_entry_using_json_response('event', entry_id, published_version, updated_state)
                 #entry.update(published_fields_state)
                 #entry.save()
                 #entry.publish()

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -16,6 +16,8 @@ def update_event_entries():
             entry_id = entry['sys']['id']
             client_entry = get_client_entry(entry_id)
             entry_had_existing_changes = client_entry.is_updated
+            if entry_id == "6jTaWeILQyXg6e8cNwVujM":
+                print(f"ENTRY HAS EXISTING CHANGES = {entry_had_existing_changes}")
             entry_is_published = client_entry.is_published
             start_date = original_fields_dict['startDate']['en-US']
 

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -48,7 +48,7 @@ def update_event_entries():
                   print(f"UPDATED ENTRY = {updated_entry}")
                 client_entry = get_client_entry(entry_id)
                 if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
-                  print(f"NEW ENTRY FIELDS = {entry.fields()}")
+                  print(f"NEW ENTRY FIELDS = {client_entry.fields()}")
                 client_entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_had_existing_changes:

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -15,9 +15,12 @@ def update_event_entries():
         if 'startDate' in original_fields_dict and 'upcomingSortOrder' in original_fields_dict and entry['sys']['id']:
             entry_id = entry['sys']['id']
             client_entry = get_client_entry(entry_id)
+            #entry_had_existing_changes = entry_is_updated(entry)
             entry_had_existing_changes = client_entry.is_updated
             if entry_id == "6jTaWeILQyXg6e8cNwVujM":
-                print(f"ENTRY HAS EXISTING CHANGES = {entry_had_existing_changes}")
+                print(f"Updated entry = {entry}")
+            if entry_id == "cfZahAKcq6SO4Sv2r77X9":
+                print(f"Un-updated entry = {entry}")
             entry_is_published = client_entry.is_published
             start_date = original_fields_dict['startDate']['en-US']
 

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -12,7 +12,7 @@ def update_event_entries():
     now = datetime.now()
     for entry in all_event_entries:
         original_fields_dict = entry.fields()
-        if 'start_date' in original_fields_dict and 'upcoming_sort_order' in original_fields_dict and entry.sys.id:
+        if 'start_date' in original_fields_dict and 'upcoming_sort_order' in original_fields_dict and entry.sys['id']:
             start_date = original_fields_dict['start_date']
             # convert from ISO time format provided by contentful in UTC timezone to naive offset datetime object
             start_date_datetime = datetime.strptime(datetime.fromisoformat(start_date).astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S.%f'), '%Y-%m-%d %H:%M:%S.%f')
@@ -28,8 +28,9 @@ def update_event_entries():
             original_fields_dict['upcomingSortOrder'] = upcoming_sort_order
             entry_has_pre_existing_changes = entry.is_updated
             if entry.is_published:
+                entry_id = entry.sys['id']
                 # if entry has changes that are not yet published then we want to publish only the already published state
-                published_fields_state = published_event_id_to_fields_mapping[entry.sys.id]
+                published_fields_state = published_event_id_to_fields_mapping[entry_id]
                 published_fields_state['upcomingSortOrder'] = upcoming_sort_order
                 # update and publish it with the values that were already published (in addition to the updated sort order)
                 entry.update(published_fields_state)

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -36,13 +36,13 @@ def update_event_entries():
                     'fields': published_fields_state,
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
-                if (entry_id == '69F1dOYJ3sqsL8pI55KTrk')
+                if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
                   print(f"OLD ENTRY FIELDS = {original_fields_dict}")
                 updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
-                if (entry_id == '69F1dOYJ3sqsL8pI55KTrk')
+                if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
                   print(f"UPDATED ENTRY = {updated_entry}")
                 entry = get_entry(entry_id)
-                if (entry_id == '69F1dOYJ3sqsL8pI55KTrk')
+                if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
                   print(f"NEW ENTRY FIELDS = {entry.fields()}")
                 entry.publish()
                 print(f"{original_fields_dict['title']} Published!")

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -36,11 +36,14 @@ def update_event_entries():
                     'fields': published_fields_state,
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
-                print("ABOUT TO RUN UPDATE")
+                if (entry_id == '69F1dOYJ3sqsL8pI55KTrk')
+                  print(f"OLD ENTRY FIELDS = {original_fields_dict}")
                 updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
-                print("ABOUT TO CALL SAVE")
-                print("SAVE CALLED")
+                if (entry_id == '69F1dOYJ3sqsL8pI55KTrk')
+                  print(f"UPDATED ENTRY = {updated_entry}")
                 entry = get_entry(entry_id)
+                if (entry_id == '69F1dOYJ3sqsL8pI55KTrk')
+                  print(f"NEW ENTRY FIELDS = {entry.fields()}")
                 entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -37,7 +37,9 @@ async def update_event_entries():
                     'fields': published_fields_state,
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
+                print("ABOUT TO RUN UPDATE")
                 asyncio.run(update_entry_using_json_response('event', entry_id, updated_state))
+                print("UPDATE RAN")
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -41,14 +41,14 @@ def update_event_entries():
                 response = update_entry_using_json_response('event', entry_id, updated_state)
                 print(f"UPDATE RAN WITH RESPONSE = {response.json()}")
                 print("ABOUT TO CALL SAVE")
-                entry.save()
+                #entry.save()
                 #entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there
                 print(f"UPDATING ENTRY")
-                entry.update(original_fields_dict)  
+                #entry.update(original_fields_dict)  
                 print(f"SAVING ENTRY")
-                entry.save()
+                #entry.save()
                 print(f"{original_fields_dict['title']} Updated back to pre-existing of {original_fields_dict}!")
 

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -1,4 +1,4 @@
-from app.metrics.contentful import get_all_entries, get_all_published_entries, update_entry_using_json_response, get_client_entry
+from app.metrics.contentful import get_all_entries, get_all_published_entries, update_entry_using_json_response, get_client_entry, publish_entry
 from datetime import datetime, timezone
 
 def update_event_entries():
@@ -33,20 +33,21 @@ def update_event_entries():
             original_fields_dict['upcomingSortOrder']['en-US'] = upcoming_sort_order
             if entry_is_published:
                 # if entry has changes that are not yet published then we want to publish only the already published state
+                if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
+                  print(f"response = {published_event_id_to_fields_mapping[entry_id]}")
                 published_fields_state = published_event_id_to_fields_mapping[entry_id]['fields']
                 published_fields_state['upcomingSortOrder']['en-US'] = upcoming_sort_order
                 updated_state = {
                     'fields': published_fields_state,
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
-                update_entry_using_json_response('event', entry_id, updated_state).json()
-                client_entry = get_client_entry(entry_id)
-                client_entry.publish()
+                #updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
+                #publish_entry(entry_id, updated_entry['sys']['version'])
             if entry_had_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there
                 original_state = {
                     'fields': original_fields_dict,
                     'metadata': original_metadata_dict
                 }
-                update_entry_using_json_response('event', entry_id, original_state).json()
+                #update_entry_using_json_response('event', entry_id, original_state).json()
 

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -33,21 +33,19 @@ def update_event_entries():
             original_fields_dict['upcomingSortOrder']['en-US'] = upcoming_sort_order
             if entry_is_published:
                 # if entry has changes that are not yet published then we want to publish only the already published state
-                if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
-                  print(f"response = {published_event_id_to_fields_mapping[entry_id]}")
                 published_fields_state = published_event_id_to_fields_mapping[entry_id]['fields']
                 published_fields_state['upcomingSortOrder']['en-US'] = upcoming_sort_order
                 updated_state = {
                     'fields': published_fields_state,
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
-                #updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
-                #publish_entry(entry_id, updated_entry['sys']['version'])
+                updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
+                publish_entry(entry_id, updated_entry['sys']['version'])
             if entry_had_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there
                 original_state = {
                     'fields': original_fields_dict,
                     'metadata': original_metadata_dict
                 }
-                #update_entry_using_json_response('event', entry_id, original_state).json()
+                update_entry_using_json_response('event', entry_id, original_state).json()
 

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -41,7 +41,6 @@ def update_event_entries():
                 }
                 updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
                 publish_entry(entry_id, updated_entry['sys']['version'])
-                print(f"{original_fields_dict['title']}")
             if entry_had_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there
                 original_state = {
@@ -49,4 +48,4 @@ def update_event_entries():
                     'metadata': original_metadata_dict
                 }
                 update_entry_using_json_response('event', entry_id, original_state).json()
-
+    print("UPDATE COMPLETE!")

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -33,11 +33,12 @@ def update_event_entries():
                 published_fields_state = published_event_id_to_fields_mapping[entry_id]
                 published_fields_state['upcomingSortOrder'] = upcoming_sort_order
                 if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
-                  print(f"{original_fields_dict['title']} State = {published_fields_state}")
+                  print(f"Original State = {original_fields_dict}")
+                  print(f"Published State = {published_fields_state}")
                 # update and publish it with the values that were already published (in addition to the updated sort order)
                 entry.update(published_fields_state)
                 entry.save()
-                entry.publish()
+                #entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -5,12 +5,9 @@ def update_event_entries():
     all_event_entries = get_all_entries("event")
     all_published_event_entries = get_all_published_entries("event")
     # Create dict with id's as the key so we do not have to iterate through each time we publish an entry
-    # We must also keep track of the corresponding version since the update method needs this 
     published_event_id_to_fields_mapping = {}
     for published_event in all_published_event_entries:
         published_event_id = published_event['sys']['id']
-        if published_event_id == '69F1dOYJ3sqsL8pI55KTrk':
-            print(f"PUBLISHED EVENT = {published_event}")
         published_event_id_to_fields_mapping[published_event_id] = published_event
     now = datetime.now()
     for entry in all_event_entries:
@@ -35,29 +32,17 @@ def update_event_entries():
                 # if entry has changes that are not yet published then we want to publish only the already published state
                 published_fields_state = published_event_id_to_fields_mapping[entry_id]['fields']
                 published_fields_state['upcomingSortOrder']['en-US'] = upcoming_sort_order
-                if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
-                  print(f"Original State = {original_fields_dict}")
-                  print(f"Published State = {published_fields_state}")
-                  updated_state = {
-                      'fields': published_fields_state,
-                      'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
-                  }
-                  temp = update_entry_using_json_response('event', entry_id, updated_state)
-                  print(f"TEMP RESPONSE = ", temp.json())
-                  entry.save()
-                #entry.update(published_fields_state)
-                #entry.save()
-                #entry.publish()
+                updated_state = {
+                    'fields': published_fields_state,
+                    'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
+                }
+                update_entry_using_json_response('event', entry_id, updated_state)
+                entry.save()
+                entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there
-                #entry.update(original_fields_dict)  
-                #entry.save()
+                entry.update(original_fields_dict)  
+                entry.save()
                 print(f"{original_fields_dict['title']} Updated back to pre-existing of {original_fields_dict}!")
-                
-            #entry.upcoming_sort_order = upcoming_sort_order
-            #entry.save()
-            # In order for prod to be correct we must publish changes. However do not publish changes for an event that has existing changes
-            #if entry.is_published:
-                #print("Entry published!")
-                #entry.publish()
+

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -38,7 +38,6 @@ def update_event_entries():
                 }
                 print("ABOUT TO RUN UPDATE")
                 updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
-                print(f"UPDATE RAN WITH RESPONSE = {response.json()}")
                 print("ABOUT TO CALL SAVE")
                 print("SAVE CALLED")
                 entry = get_entry(entry_id)

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -43,7 +43,8 @@ def update_event_entries():
                       'fields': published_fields_state,
                       'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                   }
-                  update_entry_using_json_response('event', entry_id, published_version, updated_state)
+                  temp = update_entry_using_json_response('event', entry_id, published_version, updated_state)
+                  print(f"TEMP RESPONSE = ", temp.json())
                   entry.save()
                 #entry.update(published_fields_state)
                 #entry.save()

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -1,7 +1,7 @@
 from app.metrics.contentful import get_all_entries, get_all_published_entries, update_entry_using_json_response
 from datetime import datetime, timezone
 
-async def update_event_entries():
+def update_event_entries():
     all_event_entries = get_all_entries("event")
     all_published_event_entries = get_all_published_entries("event")
     # Create dict with id's as the key so we do not have to iterate through each time we publish an entry
@@ -36,13 +36,17 @@ async def update_event_entries():
                     'fields': published_fields_state,
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
-                await update_entry_using_json_response('event', entry_id, updated_state)
+                updated_entry = update_entry_using_json_response('event', entry_id, updated_state)
+                print(f"ENTRY UPDATED = {updated_entry}")
                 entry.save()
+                print(f"SAVE CALLED")
                 entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there
+                print(f"UPDATING ENTRY")
                 entry.update(original_fields_dict)  
+                print(f"SAVING ENTRY")
                 entry.save()
                 print(f"{original_fields_dict['title']} Updated back to pre-existing of {original_fields_dict}!")
 

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -2,7 +2,7 @@ from app.metrics.contentful import get_all_entries, get_all_published_entries, u
 from datetime import datetime, timezone
 import asyncio
 
-def update_event_entries():
+async def update_event_entries():
     all_event_entries = get_all_entries("event")
     all_published_event_entries = get_all_published_entries("event")
     # Create dict with id's as the key so we do not have to iterate through each time we publish an entry
@@ -39,6 +39,7 @@ def update_event_entries():
                 }
                 update_entry_task = asyncio.create_task(update_entry_using_json_response('event', entry_id, updated_state))
                 update_entry_task.add_done_callback(entry.publish())
+                await update_entry_task
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -14,9 +14,6 @@ def update_event_entries():
         original_metadata_dict = entry['metadata']
         if 'startDate' in original_fields_dict and 'upcomingSortOrder' in original_fields_dict and entry['sys']['id']:
             entry_id = entry['sys']['id']
-            #client_entry = get_client_entry(entry_id)
-            #entry_is_published = client_entry.is_published
-            #entry_had_existing_changes = client_entry.is_updated
             entry_had_existing_changes = False
             entry_is_published = False 
             if 'publishedAt' in entry['sys']:
@@ -49,14 +46,13 @@ def update_event_entries():
                     'fields': published_fields_state,
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
-                #updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
-                #publish_entry(entry_id, updated_entry['sys']['version'])
+                updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
+                publish_entry(entry_id, updated_entry['sys']['version'])
             # after publishing, update it again with the pre-existing changes that were already there. Or if it is a draft then just update it in order to set the sort order
             if entry_had_existing_changes or not entry_is_published:
-                print(f"{original_fields_dict['title']} had existing changes")
                 original_state = {
                     'fields': original_fields_dict,
                     'metadata': original_metadata_dict
                 }
-                #update_entry_using_json_response('event', entry_id, original_state).json()
+                update_entry_using_json_response('event', entry_id, original_state).json()
     print("UPDATE COMPLETE!")

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -55,4 +55,3 @@ def update_event_entries():
                     'metadata': original_metadata_dict
                 }
                 update_entry_using_json_response('event', entry_id, original_state).json()
-    print("UPDATE COMPLETE!")

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -1,4 +1,4 @@
-from app.metrics.contentful import get_all_entries, get_all_published_entries, update_entry_using_json_response
+from app.metrics.contentful import get_all_entries, get_all_published_entries, update_entry_using_json_response, get_entry
 from datetime import datetime, timezone
 
 def update_event_entries():
@@ -37,17 +37,18 @@ def update_event_entries():
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
                 print("ABOUT TO RUN UPDATE")
-                response = update_entry_using_json_response('event', entry_id, updated_state)
+                updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
                 print(f"UPDATE RAN WITH RESPONSE = {response.json()}")
                 print("ABOUT TO CALL SAVE")
                 print("SAVE CALLED")
+                entry = get_entry(entry_id)
                 entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there
                 print(f"UPDATING ENTRY")
-                #entry.update(original_fields_dict)  
+                entry.update(original_fields_dict)  
                 print(f"SAVING ENTRY")
-                #entry.save()
+                entry.save()
                 print(f"{original_fields_dict['title']} Updated back to pre-existing of {original_fields_dict}!")
 

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -34,7 +34,6 @@ def update_event_entries():
                 entry_id = entry.sys['id']
                 # if entry has changes that are not yet published then we want to publish only the already published state
                 published_fields_state = published_event_id_to_fields_mapping[entry_id]['fields']
-                published_version = published_event_id_to_fields_mapping[entry_id]['sys']['publishedVersion']
                 published_fields_state['upcomingSortOrder'] = upcoming_sort_order
                 if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
                   print(f"Original State = {original_fields_dict}")
@@ -43,7 +42,7 @@ def update_event_entries():
                       'fields': published_fields_state,
                       'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                   }
-                  temp = update_entry_using_json_response('event', entry_id, published_version, updated_state)
+                  temp = update_entry_using_json_response('event', entry_id, updated_state)
                   print(f"TEMP RESPONSE = ", temp.json())
                   entry.save()
                 #entry.update(published_fields_state)

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -14,7 +14,7 @@ def update_event_entries():
         original_fields_dict = entry['fields']
         original_metadata_dict = entry['metadata']
         if 'start_date' in original_fields_dict and 'upcoming_sort_order' in original_fields_dict and entry['sys']['id']:
-            entry_id = entry.sys['id']
+            entry_id = entry['sys']['id']
             client_entry = get_client_entry(entry_id)
             entry_had_existing_changes = client_entry.is_updated
             entry_is_published = client_entry.is_published

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -46,10 +46,10 @@ def update_event_entries():
                 updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
                 if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
                   print(f"UPDATED ENTRY = {updated_entry}")
-                entry = get_entry(entry_id)
+                client_entry = get_client_entry(entry_id)
                 if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
                   print(f"NEW ENTRY FIELDS = {entry.fields()}")
-                entry.publish()
+                client_entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_had_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -24,7 +24,7 @@ def update_event_entries():
                 # convert UTC time strings into datetime objects
                 entry_updated_at = datetime.strptime(entry['sys']['updatedAt'], '%Y-%m-%dT%H:%M:%S.%fZ')
                 entry_published_at = datetime.strptime(entry['sys']['publishedAt'], '%Y-%m-%dT%H:%M:%S.%fZ')
-                if entry_updated_at - entry_published_at > 0:
+                if (entry_updated_at - entry_published_at).total_seconds() > 0:
                     entry_had_existing_changes = True
             
             start_date = original_fields_dict['startDate']['en-US']

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -1,7 +1,7 @@
 from app.metrics.contentful import get_all_entries, get_all_published_entries, update_entry_using_json_response
 from datetime import datetime, timezone
 
-def update_event_entries():
+async def update_event_entries():
     all_event_entries = get_all_entries("event")
     all_published_event_entries = get_all_published_entries("event")
     # Create dict with id's as the key so we do not have to iterate through each time we publish an entry
@@ -36,7 +36,7 @@ def update_event_entries():
                     'fields': published_fields_state,
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
-                update_entry_using_json_response('event', entry_id, updated_state)
+                await update_entry_using_json_response('event', entry_id, updated_state)
                 entry.save()
                 entry.publish()
                 print(f"{original_fields_dict['title']} Published!")

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -9,7 +9,6 @@ def update_event_entries():
     for published_event in all_published_event_entries:
         published_event_id = published_event['sys']['id']
         published_event_id_to_fields_mapping[published_event_id] = published_event
-    now = datetime.now()
     for entry in all_event_entries:
         original_fields_dict = entry['fields']
         original_metadata_dict = entry['metadata']
@@ -22,7 +21,7 @@ def update_event_entries():
 
             # convert from ISO time format provided by contentful in UTC timezone to naive offset datetime object
             start_date_datetime = datetime.strptime(datetime.fromisoformat(start_date).astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S.%f'), '%Y-%m-%d %H:%M:%S.%f')
-            time_from_event_in_seconds = (start_date_datetime - now).total_seconds()
+            time_from_event_in_seconds = (start_date_datetime - datetime.now()).total_seconds()
             time_from_event_in_days = time_from_event_in_seconds / 86400
             # in order to maintain the correct event sorting for upcoming (closet first, followed by closest in the future, followed by closest in the past),
             # we cannot simply keep track of the time from the event. Instead we take the inverse of the dates in the future so that they are less than the nearest future dates.
@@ -32,7 +31,6 @@ def update_event_entries():
             if time_from_event_in_days < 0:
                 upcoming_sort_order = time_from_event_in_days
             original_fields_dict['upcomingSortOrder']['en-US'] = upcoming_sort_order
-
             if entry_is_published:
                 # if entry has changes that are not yet published then we want to publish only the already published state
                 published_fields_state = published_event_id_to_fields_mapping[entry_id]['fields']
@@ -41,24 +39,14 @@ def update_event_entries():
                     'fields': published_fields_state,
                     'metadata': published_event_id_to_fields_mapping[entry_id]['metadata']
                 }
-                if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
-                  print(f"OLD ENTRY FIELDS = {original_fields_dict}")
-                updated_entry = update_entry_using_json_response('event', entry_id, updated_state).json()
-                if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
-                  print(f"UPDATED ENTRY = {updated_entry}")
+                update_entry_using_json_response('event', entry_id, updated_state).json()
                 client_entry = get_client_entry(entry_id)
-                if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
-                  print(f"NEW ENTRY FIELDS = {client_entry.fields()}")
                 client_entry.publish()
-                print(f"{original_fields_dict['title']} Published!")
             if entry_had_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there
-                print(f"UPDATING ENTRY BACK TO ORIGINAL")
                 original_state = {
                     'fields': original_fields_dict,
                     'metadata': original_metadata_dict
                 }
-                original_entry = update_entry_using_json_response('event', entry_id, original_state).json()
-                #entry.update(original_fields_dict) 
-                print(f"{original_fields_dict['title']} Updated back to pre-existing of {original_entry}!")
+                update_entry_using_json_response('event', entry_id, original_state).json()
 

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -1,6 +1,5 @@
 from app.metrics.contentful import get_all_entries, get_all_published_entries, update_entry_using_json_response
 from datetime import datetime, timezone
-import asyncio
 
 async def update_event_entries():
     all_event_entries = get_all_entries("event")

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -17,7 +17,7 @@ def update_event_entries():
             client_entry = get_client_entry(entry_id)
             #entry_had_existing_changes = entry_is_updated(entry)
             entry_had_existing_changes = client_entry.is_updated
-            if entry_id == "2uumvOZ3blED0zQ0Vb65LS":
+            if entry_id not in published_event_id_to_fields_mapping:
                 print(f"Draft entry = {entry}")
             entry_is_published = client_entry.is_published
             start_date = original_fields_dict['startDate']['en-US']

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -38,7 +38,7 @@ def update_event_entries():
                 # update and publish it with the values that were already published (in addition to the updated sort order)
                 #entry.update(published_fields_state)
                 #entry.save()
-                entry.publish()
+                #entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -36,9 +36,9 @@ def update_event_entries():
                   print(f"Original State = {original_fields_dict}")
                   print(f"Published State = {published_fields_state}")
                 # update and publish it with the values that were already published (in addition to the updated sort order)
-                entry.update(published_fields_state)
-                entry.save()
-                #entry.publish()
+                #entry.update(published_fields_state)
+                #entry.save()
+                entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there

--- a/scripts/update_contentful_entries.py
+++ b/scripts/update_contentful_entries.py
@@ -32,16 +32,18 @@ def update_event_entries():
                 # if entry has changes that are not yet published then we want to publish only the already published state
                 published_fields_state = published_event_id_to_fields_mapping[entry_id]
                 published_fields_state['upcomingSortOrder'] = upcoming_sort_order
+                if entry_id == '69F1dOYJ3sqsL8pI55KTrk':
+                  print(f"{original_fields_dict['title']} State = {published_fields_state}")
                 # update and publish it with the values that were already published (in addition to the updated sort order)
-                entry.update(published_fields_state)
-                entry.save()
-                entry.publish()
+                #entry.update(published_fields_state)
+                #entry.save()
+                #entry.publish()
                 print(f"{original_fields_dict['title']} Published!")
             if entry_has_pre_existing_changes:
                 # after publishing, save it again with the pre-existing changes that were already there
-                entry.update(original_fields_dict)  
-                entry.save()
-                print(f"{original_fields_dict['title']} Updated back to pre-existing and saved!")
+                #entry.update(original_fields_dict)  
+                #entry.save()
+                print(f"{original_fields_dict['title']} Updated back to pre-existing of {original_fields_dict}!")
                 
             #entry.upcoming_sort_order = upcoming_sort_order
             #entry.save()


### PR DESCRIPTION
# Description

Added logic to publish events after updating them if they are published so that the change to their upcoming sort order property takes effect on production.

In order to account for entries that have been published previously, but have had un-published changes since then, we have to save their current state, get their published state, update the umcoming sort order property, and publish. Then update/save them again with the previously saved current state so that any changes are not lost. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
