### PR TITLE
Add dataset name to monthly stats

### DIFF
--- a/scripts/monthly_downloads_html_template.py
+++ b/scripts/monthly_downloads_html_template.py
@@ -5,10 +5,10 @@ html_start = \
 <tbody> \
 <tr> \
 <td style="width: 30%;">Dataset Name</td> \
-<td style="width: 18%;">Dataset ID</td> \
-<td style="width: 18%;">Version</td> \
-<td style="width: 18%;">Origin</td> \
-<td style="width: 18%;">Downloads</td> \
+<td style="width: 17%;">Dataset ID</td> \
+<td style="width: 17%;">Version</td> \
+<td style="width: 17%;">Origin</td> \
+<td style="width: 17%;">Downloads</td> \
 </tr>'
 
 
@@ -21,11 +21,11 @@ def create_html_template(datasets_download_info):
     html_string = html_start
     for dataset in datasets_download_info:
         html_string += f'<tr> \
-        <td style="width: 30;">{dataset["name"]}</td> \
-        <td style="width: 18;">{dataset["datasetId"]}</td> \
-        <td style="width: 18;">{dataset["version"]}</td> \
-        <td style="width: 18%;">{dataset["origin"]}</td> \
-        <td style="width: 18%;">{dataset["downloads"]}</td> \
+        <td style="width: 32%;">{dataset["name"]}</td> \
+        <td style="width: 17%;">{dataset["datasetId"]}</td> \
+        <td style="width: 17%;">{dataset["version"]}</td> \
+        <td style="width: 17%;">{dataset["origin"]}</td> \
+        <td style="width: 17%;">{dataset["downloads"]}</td> \
         </tr>'
     html_string += html_end
     return html_string

--- a/scripts/monthly_downloads_html_template.py
+++ b/scripts/monthly_downloads_html_template.py
@@ -4,10 +4,11 @@ html_start = \
 <table style="border-collapse: collapse; width: 100%;" border="1"> \
 <tbody> \
 <tr> \
-<td style="width: 27.3912%;">Dataset ID</td> \
-<td style="width: 22.6088%;">Version</td> \
-<td style="width: 25%;">Origin</td> \
-<td style="width: 25%;">Downloads</td> \
+<td style="width: 30%;">Dataset Name</td> \
+<td style="width: 18%;">Dataset ID</td> \
+<td style="width: 18%;">Version</td> \
+<td style="width: 18%;">Origin</td> \
+<td style="width: 18%;">Downloads</td> \
 </tr>'
 
 
@@ -20,10 +21,11 @@ def create_html_template(datasets_download_info):
     html_string = html_start
     for dataset in datasets_download_info:
         html_string += f'<tr> \
-        <td style="width: 27.3912%;">{dataset["datasetId"]}</td> \
-        <td style="width: 22.6088%;">{dataset["version"]}</td> \
-        <td style="width: 25%;">{dataset["origin"]}</td> \
-        <td style="width: 25%;">{dataset["downloads"]}</td> \
+        <td style="width: 30;">{dataset["name"]}</td> \
+        <td style="width: 18;">{dataset["datasetId"]}</td> \
+        <td style="width: 18;">{dataset["version"]}</td> \
+        <td style="width: 18%;">{dataset["origin"]}</td> \
+        <td style="width: 18%;">{dataset["downloads"]}</td> \
         </tr>'
     html_string += html_end
     return html_string

--- a/scripts/monthly_downloads_html_template.py
+++ b/scripts/monthly_downloads_html_template.py
@@ -4,11 +4,11 @@ html_start = \
 <table style="border-collapse: collapse; width: 100%;" border="1"> \
 <tbody> \
 <tr> \
-<td style="width: 30%;">Dataset Name</td> \
-<td style="width: 17%;">Dataset ID</td> \
-<td style="width: 17%;">Version</td> \
-<td style="width: 17%;">Origin</td> \
-<td style="width: 17%;">Downloads</td> \
+<td style="width: 60%;">Dataset Name</td> \
+<td style="width: 6%;">ID</td> \
+<td style="width: 10%;">Version</td> \
+<td style="width: 10%;">Origin</td> \
+<td style="width: 14%;">Downloads</td> \
 </tr>'
 
 
@@ -21,11 +21,11 @@ def create_html_template(datasets_download_info):
     html_string = html_start
     for dataset in datasets_download_info:
         html_string += f'<tr> \
-        <td style="width: 32%;">{dataset["name"]}</td> \
-        <td style="width: 17%;">{dataset["datasetId"]}</td> \
-        <td style="width: 17%;">{dataset["version"]}</td> \
-        <td style="width: 17%;">{dataset["origin"]}</td> \
-        <td style="width: 17%;">{dataset["downloads"]}</td> \
+        <td style="width: 60%;">{dataset["name"]}</td> \
+        <td style="width: 6%;">{dataset["datasetId"]}</td> \
+        <td style="width: 10%;">{dataset["version"]}</td> \
+        <td style="width: 10%;">{dataset["origin"]}</td> \
+        <td style="width: 14%;">{dataset["downloads"]}</td> \
         </tr>'
     html_string += html_end
     return html_string

--- a/scripts/monthly_stats.py
+++ b/scripts/monthly_stats.py
@@ -121,6 +121,8 @@ class MonthlyStats(object):
 
             # filter to only have datsets with downloads
             downloadInfo = [d for d in download_stats if dataset['id'] == d['datasetId']]
+
+            downloadInfo = self.add_dataset_name_to_download_info(dataset, downloadInfo)
             for contributor in dataset['contributors']:
                 orcid_id = contributor['orcid']
 
@@ -132,6 +134,12 @@ class MonthlyStats(object):
                     users[orcid_id]['datasets'] += downloadInfo
 
         return users
+
+    def add_dataset_name_to_download_info(self, dataset, downloadInfo):
+        for i in range(0, len(downloadInfo)):
+            downloadInfo[i]['name'] = dataset['name']
+        return downloadInfo
+
 
     # send email using sendgrid
     def send_email(self, email_address, email_body):

--- a/scripts/monthly_stats.py
+++ b/scripts/monthly_stats.py
@@ -143,12 +143,15 @@ class MonthlyStats(object):
 
     # send email using sendgrid
     def send_email(self, email_address, email_body):
-        if not self.debug_mode:
-            email_destination = email_address
-        else:
+        if self.debug_mode:
             email_destination = self.debug_email
-
-        return self.send_grid.sendgrid_email_with_unsubscribe_group(Config.METRICS_EMAIL_ADDRESS,
+            return self.send_grid.sendgrid_email_with_unsubscribe_group(Config.METRICS_EMAIL_ADDRESS,
+                                                                    email_destination,
+                                                                    'SPARC monthly dataset download summary',
+                                                                    email_body)
+        elif Config.DEPLOY_ENV is 'production':
+            email_destination = email_address
+            return self.send_grid.sendgrid_email_with_unsubscribe_group(Config.METRICS_EMAIL_ADDRESS,
                                                                     email_destination,
                                                                     'SPARC monthly dataset download summary',
                                                                     email_body)

--- a/tests/test_monthly_stats.py
+++ b/tests/test_monthly_stats.py
@@ -13,18 +13,21 @@ test_data = {
         "datasets": [
             {
                 "datasetId": 230,
+                "name": "Test dataset 1",
                 "version": 1,
                 "origin": "SPARC",
                 "downloads": 1
             },
             {
                 "datasetId": 225,
+                "name": "Test dataset 2",
                 "version": 1,
                 "origin": "SPARC",
                 "downloads": 1
             },
             {
                 "datasetId": 141,
+                "name": "Test dataset 3",
                 "version": 2,
                 "origin": "SPARC",
                 "downloads": 1


### PR DESCRIPTION
# Description

Add dataset name to monthly stats email.

This PR also fixes a bug where everyone got duplicate emails last month.
( I previously forgot to add a check for if the sparc-api instance was on production )

![image](https://user-images.githubusercontent.com/37255664/224194961-be9ffbf2-8c97-4def-ad93-c0f2f8b3c0d8.png)



Wrike ticket for this is here:
https://www.wrike.com/open.htm?id=1038980939


## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Tests run locally and emails checked in a browser


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
