### PR TITLE
Changes to get the `/simulation_ui_file` endpoint to work with any S3 bucket name

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -194,7 +194,13 @@ def test_non_existing_simulation_ui_file(client):
     assert r.status_code == 404
 
 
-def test_simulation_ui_file(client):
+def test_simulation_ui_file_old_s3_bucket(client):
     r = client.get('/simulation_ui_file/135')
     assert r.status_code == 200
-    assert r.get_json()['input'][1]['visible'] == 'sm == 1'
+    assert r.get_json()['simulation']['solvers'][0]['name'] == 'simcore/services/comp/opencor'
+
+
+def test_simulation_ui_file_new_s3_bucket(client):
+    r = client.get('/simulation_ui_file/308')
+    assert r.status_code == 200
+    assert r.get_json()['simulation']['solvers'][0]['name'] == 'simcore/services/comp/kember-cardiac-model'


### PR DESCRIPTION
# Description

Datasets can now be in different S3 bucket names. This PR focuses on the `simulation_ui_file` endpoint and makes sure that it works with any dataset, no matter the S3 bucket name it uses.


## Type of change

Delete those that don't apply.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

This has been tested locally using things like:
 - http://localhost:8000/simulation_ui_file/135 (old S3 bucket name);
 - http://localhost:8000/simulation_ui_file/157 (old S3 bucket name); and
 - http://localhost:8000/simulation_ui_file/308 (new S3 bucket name).


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added unit tests that prove my fix is effective or that my feature works