### PR TITLE
Add api to get the whole body scaffold info.

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -812,14 +812,14 @@ def get_owner_email(owner_id):
 # dataset id and version which can be used to construct the url
 @app.route("/get_body_scaffold_info/<species>", methods=["GET"])
 def get_body_scaffold_info(species):
-    # Filter to find user based on provided int id
     id = get_body_scaffold_dataset_id(species)
     if id:
-        result = process_get_first_scaffold_info(dataset_search(create_pennsieve_identifier_query(id)))
+        query = create_pennsieve_identifier_query(id)
+        result = process_get_first_scaffold_info(dataset_search(query))
         if result:
             return result
 
-    return abort(400, description=f"Whole body info not found for {species}")
+    return abort(404, description=f"Whole body info not found for {species}")
 
 @app.route("/thumbnail/<image_id>", methods=["GET"])
 def thumbnail_by_image_id(image_id, recursive_call=False):

--- a/app/main.py
+++ b/app/main.py
@@ -33,15 +33,15 @@ from requests.auth import HTTPBasicAuth
 
 from app.scicrunch_requests import create_doi_query, create_filter_request, create_facet_query, create_doi_aggregate, create_title_query, \
     create_identifier_query, create_pennsieve_identifier_query, create_field_query, create_request_body_for_curies, create_onto_term_query, \
-    create_multiple_doi_query, create_multiple_discoverId_query
+    create_multiple_doi_query, create_multiple_discoverId_query, get_body_scaffold_dataset_id
 from scripts.email_sender import EmailSender, feedback_email, issue_reporting_email, creation_request_confirmation_email
 from threading import Lock
 from xml.etree import ElementTree
 
 from app.config import Config
 from app.dbtable import MapTable, ScaffoldTable, FeaturedDatasetIdSelectorTable
-from app.scicrunch_process_results import reform_dataset_results, process_results, reform_aggregation_results, reform_curies_results, \
-    reform_related_terms
+from app.scicrunch_process_results import process_results, process_get_first_scaffold_info, reform_aggregation_results, \
+    reform_curies_results, reform_dataset_results, reform_related_terms
 from app.serializer import ContactRequestSchema
 from app.utilities import img_to_base64_str
 from app.osparc import start_simulation as do_start_simulation
@@ -539,6 +539,7 @@ def get_segmentation_info_from_file(bucket_name=Config.DEFAULT_S3_BUCKET_NAME):
 
     s3BucketName = query_args.get("s3BucketName", bucket_name)
     dataset_path = query_args.get('dataset_path')
+
     try:
         response = s3.get_object(
             Bucket=s3BucketName,
@@ -806,6 +807,19 @@ def get_owner_email(owner_id):
     else:
         return jsonify({"email": res[0].email})
 
+# Get information of the latest body scaffold for species.
+# This endpoint returns the metadata file path, bucket,
+# dataset id and version which can be used to construct the url
+@app.route("/get_body_scaffold_info/<species>", methods=["GET"])
+def get_body_scaffold_info(species):
+    # Filter to find user based on provided int id
+    id = get_body_scaffold_dataset_id(species)
+    if id:
+        result = process_get_first_scaffold_info(dataset_search(create_pennsieve_identifier_query(id)))
+        if result:
+            return result
+
+    return abort(400, description=f"Whole body info not found for {species}")
 
 @app.route("/thumbnail/<image_id>", methods=["GET"])
 def thumbnail_by_image_id(image_id, recursive_call=False):
@@ -1347,3 +1361,4 @@ def event_updated():
                 abort(400, description=f'Invalid event data: {event}')
         else:
             abort(400, description="Missing event data")
+

--- a/app/scicrunch_process_results.py
+++ b/app/scicrunch_process_results.py
@@ -1,6 +1,7 @@
 import importlib
 import json
 import re
+from app.config import Config
 from flask import jsonify
 
 from app.scicrunch_processing_common import SKIPPED_OBJ_ATTRIBUTES
@@ -70,6 +71,20 @@ def _remove_unused_files_information(obj_list):
 def process_results(results):
     return jsonify({'numberOfHits': results['hits']['total'], 'results': _prepare_results(results)})
 
+# process the search result to get the first scaffold of the first dataset
+def process_get_first_scaffold_info(results):
+    results = _prepare_results(results)
+    # iterate through to get the first scaffold
+    for result in results:
+        if 'abi-scaffold-metadata-file' in result and len(result['abi-scaffold-metadata-file']) > 0:
+            path = result['abi-scaffold-metadata-file'][0].get('dataset', {}).get('path')
+            id = result.get('dataset_identifier', 0)
+            version = result.get('dataset_version', 0)
+            s3uri = result.get('s3uri', Config.DEFAULT_S3_BUCKET_NAME)
+            return jsonify({'path':path, 'id': id, 'version': version, 's3uri': s3uri})
+    
+    #None found, let the caller handle that
+    return None
 
 def reform_dataset_results(results):
     processed_outputs = []

--- a/app/scicrunch_process_results.py
+++ b/app/scicrunch_process_results.py
@@ -77,12 +77,15 @@ def process_get_first_scaffold_info(results):
     # iterate through to get the first scaffold
     for result in results:
         if 'abi-scaffold-metadata-file' in result and len(result['abi-scaffold-metadata-file']) > 0:
-            path = result['abi-scaffold-metadata-file'][0].get('dataset', {}).get('path')
-            id = result.get('dataset_identifier', 0)
-            version = result.get('dataset_version', 0)
-            s3uri = result.get('s3uri', Config.DEFAULT_S3_BUCKET_NAME)
-            return jsonify({'path':path, 'id': id, 'version': version, 's3uri': s3uri})
-    
+            try:
+                path = result['abi-scaffold-metadata-file'][0]['dataset']['path']
+                id = result['dataset_identifier']
+                version = result['dataset_version']
+                s3uri = result['s3uri']
+                return jsonify({'path':path, 'id': id, 'version': version, 's3uri': s3uri})
+            except KeyError:
+                return None
+
     #None found, let the caller handle that
     return None
 

--- a/app/scicrunch_requests.py
+++ b/app/scicrunch_requests.py
@@ -1,3 +1,13 @@
+#Hardcoded list for getting whole body scaffold,
+#Update this list as needed
+BODY_SCAFFOLD_DATASET = {
+    'human': 307,
+    'mouse': 167,
+    'pig': 227,
+    'rat': 147
+}
+
+
 def create_query_string(query_string):
     return {
         "from": 0,
@@ -216,6 +226,13 @@ def create_filter_request(query, terms, facets, size, start):
     data["query"]["query_string"]["query"] = qs
     return data
 
+# Get the id for the current body scaffold dataset id
+# of the specified species
+def get_body_scaffold_dataset_id(species):
+    if species:
+        return BODY_SCAFFOLD_DATASET.get(species.lower(), None)
+
+    return None
 
 # Type map is used to map SciCrunch paths to given facet
 # genotype is deprecated.

--- a/tests/test_scicrunch.py
+++ b/tests/test_scicrunch.py
@@ -394,6 +394,14 @@ def test_raw_response_structure(client):
     #     print(k, data['hits']['hits'][0][k])
 
 
+def test_get_body_scaffold_info(client):
+    # Test if we get a shorter list of uberons with species specified
+    r = client.get('/get_body_scaffold_info/human')
+    result = json.loads(r.data)
+    assert result['id'] == '307'
+    assert result['path'] == 'derivative/human_body_metadata.json'
+    assert 'prd-sparc-discover-use1' in result['s3uri']
+
 def test_getting_curies(client):
     # Test if we get a shorter list of uberons with species specified
     r = client.get('/get-organ-curies/')


### PR DESCRIPTION
# Description

Add a new api endpoint to get sufficient dataset info to construct the url for the latest whole body scaffold. This is tracked in the following [map-core sprint ticket](https://www.wrike.com/open.htm?id=986729525).


## Type of change

Delete those that don't apply.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have added a test and this can be test using the following endpoint - https://alan-wu-portal-api.herokuapp.com/get_body_scaffold_info/human

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
