### PR TITLE
Remove two items from skipped mimetype list

### DIFF
--- a/app/scicrunch_processing_common.py
+++ b/app/scicrunch_processing_common.py
@@ -84,8 +84,6 @@ SKIPPED_MIME_TYPES = [
     'font/ttf',
     'image/gznii',
     'image/vnd.nikon.nd2',
-    'image/vnd.ome.xml+jp2',
-    'image/vnd.ome.xml+jpx',
     'image/vnd.ome.xml+tiff',
     'image/vnd.zeiss.czi',
     'image/x-coreldraw',


### PR DESCRIPTION
# Description

An issue was spotted when viewing some biolucida from the gallery as reported [here](https://www.wrike.com/open.htm?id=1088255960).

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This [link](https://alan-wu-sparc-app.herokuapp.com/datasets/biolucidaviewer/12987?view=MTI5ODctY29sLTIwOA%3D%3D&dataset_version=1&dataset_id=304&item_id=N%3Apackage%3Ac4f6de91-030c-47f4-ac94-f88fef787698) should work with this fix.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
