### PR TITLE
Monthly stats logging hot fix:

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -22,6 +22,7 @@ class Config(object):
     SES_ARN = os.environ.get("SES_ARN")
     SES_SENDER = os.environ.get("SES_SENDER")
     METRICS_EMAIL_ADDRESS = os.environ.get("METRICS_EMAIL_ADDRESS", "metrics@sparc.science")
+    TESTING_EMAIL_ADDRESS = os.environ.get("TESTING_EMAIL_ADDRESS", "jessekhora@gmail.com")
     COMMS_EMAIL = os.environ.get("COMMS_EMAIL")
     SPARC_PORTAL_AWS_KEY = os.environ.get("SPARC_PORTAL_USER_ID")
     SPARC_PORTAL_AWS_SECRET = os.environ.get("SPARC_PORTAL_USER_SECRET")

--- a/scripts/monthly_stats.py
+++ b/scripts/monthly_stats.py
@@ -25,6 +25,10 @@ class MonthlyStats(object):
         self.run_day = 1  # This is the day of the month emails will be sent
         self.debug_email = debug_email
         self.debug_mode = debug_mode
+        if debug_mode:
+            self.logging_address = debug_email
+        else:
+            self.logging_address = Config.METRICS_EMAIL_ADDRESS
 
     # daily_run_check runs on a set day of the month. However, since we do nt want to send two emails to users if the
     #       app restarts on the first day of the month, We assume an email has already been sent if the app has just
@@ -177,11 +181,11 @@ class MonthlyStats(object):
     def send_logging_email(self, message):
         try:
             response = self.send_grid.sendgrid_email_with_unsubscribe_group(Config.METRICS_EMAIL_ADDRESS,
-                                                                 Config.METRICS_EMAIL_ADDRESS,
+                                                                 self.logging_address,
                                                                  'SPARC monthly dataset download summary',
                                                                  message)
             if response.status_code == 202:
-                logging.info(f'Logging email sent successfully to {Config.METRICS_EMAIL_ADDRESS} (202)')
+                logging.info(f'Logging email sent successfully to {self.logging_address} (202)')
             elif response.status_code == 403:
                 logging.error('Could not send sendgrid email because rate limit is hit (403)')
             elif response.status_code == 401:

--- a/tests/test_monthly_stats.py
+++ b/tests/test_monthly_stats.py
@@ -6,7 +6,7 @@ from nose.tools import assert_true
 #  The email address below can be modified to check the emails are sending and look as expected
 #  (using any email you control is fine as long as it is not pushed to github)
 
-test_email_recipient = 'myname@domain.com'
+test_email_recipient = Config.TESTING_EMAIL_ADDRESS
 
 test_data = {
     "0000-0002-3722-6351": {

--- a/tests/test_monthly_stats.py
+++ b/tests/test_monthly_stats.py
@@ -71,4 +71,4 @@ def test_full_run():  # For each recipient, this will send an email to the test_
 
 def test_log_email():
     response = ms.send_logging_email('testing log email')
-    assert_true(response == 202)
+    assert_true(response.status_code == 202)


### PR DESCRIPTION
# Description

 Following #169, there were a few errors that popped up in the logging and testing runs of monthly stats.
 
 This PR is a hotfix that fixes those two issues:
 
 - fix error where responses were not being returned in the full run
 - fix issue in testing logic
 - fix log emails not returning response
 


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Ran the monthly stats tests using metrics@sparc.science and my sendgrid account. 

Both are passing all tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
