### PR TITLE
Upgrade psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ six==1.13.0
 SQLAlchemy==1.3.20
 urllib3==1.26.4
 Werkzeug==0.16.0
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.5
 APScheduler==3.7.0
 google-api-python-client==2.52.0
 oauth2client==4.1.3


### PR DESCRIPTION
# Description

Now that Heroku is building with python 3.11.3 upgrading psycopg2-binary to 2.9.5 which you can see here https://www.psycopg.org/docs/news.html#what-s-new-in-psycopg-2-9-5 is when they added support for 3.11

## Type of change

Delete those that don't apply.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally, won't be able to verify for sure until deployed to heroku

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
