### PR TITLE
Reduce size of the request to pennsieve

### DIFF
--- a/scripts/monthly_stats.py
+++ b/scripts/monthly_stats.py
@@ -129,9 +129,10 @@ class MonthlyStats(object):
     # Get details for a given metrics object
     def get_dataset_details_from_pennsieve(self, metrics):
         # send a request asking for info on the datsets with downloads
+        uniqueIds = set([d['datasetId'] for d in metrics])
         r = requests.get(f'{Config.PENNSIEVE_API_HOST}/discover/datasets', {
             'limit': 1000,
-            'ids': [d['datasetId'] for d in metrics]
+            'ids': uniqueIds
         })
         r.raise_for_status()
         return r.json()['datasets']


### PR DESCRIPTION
# Description
This PR fixes the issue currently occurring in testing for monthly stats.

There were a lot of duplicates in the URL that was getting sent to pennsieve for dataset info. We were sometimes hitting the max URL length, I have removed the duplicates, which has about halved the size, allowing us to request info for about 240  datasets. 

Once we get to about the 600 dataset range we will likely need to split this into multiple requests.




## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
