### PR TITLE
Now convert ',' & ' ' to '_' for s3 resource paths

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -427,10 +427,13 @@ def direct_download_url(path, bucket_name=Config.DEFAULT_S3_BUCKET_NAME):
     query_args = request.args
     s3BucketName = query_args.get("s3BucketName", bucket_name)
 
+    s3_path = path.replace(' ', '_')
+    s3_path = s3_path.replace(',','_')
+
     try:
         head_response = s3.head_object(
             Bucket=s3BucketName,
-            Key=path,
+            Key=s3_path,
             RequestPayer="requester"
         )
         content_length = head_response.get('ContentLength', Config.DIRECT_DOWNLOAD_LIMIT)
@@ -443,7 +446,7 @@ def direct_download_url(path, bucket_name=Config.DEFAULT_S3_BUCKET_NAME):
 
     response = s3.get_object(
         Bucket=s3BucketName,
-        Key=path,
+        Key=s3_path,
         RequestPayer="requester"
     )
 


### PR DESCRIPTION
# Description

Now convert ',' & ' ' to '_' for s3 resource paths. 

This is needed because s3 apparently does not store spaces or commas in file names. 

This normally is done on the front end, but some packages in mapintegratedvuer call the sparc-api directly so I think it makes sense in terms of consistency to also do the string replacement on the function that the mapintegratedvuer calls here

This PR will also fix a bug where some files are not showing on the /maps page which have spaces or commas

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Tested locally, Ran the sparc-api tests


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
