### PR TITLE
S3 path fix

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,7 +44,7 @@ from app.dbtable import MapTable, ScaffoldTable, FeaturedDatasetIdSelectorTable
 from app.scicrunch_process_results import process_results, process_get_first_scaffold_info, reform_aggregation_results, \
     reform_curies_results, reform_dataset_results, reform_related_terms, reform_anatomy_results
 from app.serializer import ContactRequestSchema
-from app.utilities import img_to_base64_str, check_path_in_mangled_list
+from app.utilities import img_to_base64_str, get_path_from_mangled_list
 from app.osparc.osparc import start_simulation as do_start_simulation
 from app.osparc.osparc import check_simulation as do_check_simulation
 from app.biolucida_process_results import process_results as process_biolucida_results
@@ -452,7 +452,7 @@ def direct_download_url(path, bucket_name=Config.DEFAULT_S3_BUCKET_NAME):
 
     # If the file does not exist, check if the name was mangled
     if response[0] == 404:
-        s3_path_modified = check_path_in_mangled_list(path)
+        s3_path_modified = get_path_from_mangled_list(path)
         if s3_path_modified == s3_path:
             abort(404, description=f'Provided path was not found on the s3 resource')  # Abort if path did not change
 

--- a/app/main.py
+++ b/app/main.py
@@ -44,7 +44,7 @@ from app.dbtable import MapTable, ScaffoldTable, FeaturedDatasetIdSelectorTable
 from app.scicrunch_process_results import process_results, process_get_first_scaffold_info, reform_aggregation_results, \
     reform_curies_results, reform_dataset_results, reform_related_terms, reform_anatomy_results
 from app.serializer import ContactRequestSchema
-from app.utilities import img_to_base64_str
+from app.utilities import img_to_base64_str, check_path_in_mangled_list
 from app.osparc.osparc import start_simulation as do_start_simulation
 from app.osparc.osparc import check_simulation as do_check_simulation
 from app.biolucida_process_results import process_results as process_biolucida_results
@@ -379,11 +379,12 @@ def url_exists(path, bucket_name=Config.DEFAULT_S3_BUCKET_NAME):
 
     query_args = request.args
     s3BucketName = query_args.get("s3BucketName", bucket_name)
+    s3_path = check_path_in_mangled_list(path)
 
     try:
         head_response = s3.head_object(
             Bucket=s3BucketName,
-            Key=path,
+            Key=s3_path,
             RequestPayer="requester"
         )
     except ClientError:
@@ -426,11 +427,12 @@ def direct_download_url(path, bucket_name=Config.DEFAULT_S3_BUCKET_NAME):
 
     query_args = request.args
     s3BucketName = query_args.get("s3BucketName", bucket_name)
+    s3_path = check_path_in_mangled_list(path)
 
     try:
         head_response = s3.head_object(
             Bucket=s3BucketName,
-            Key=path,
+            Key=s3_path,
             RequestPayer="requester"
         )
         content_length = head_response.get('ContentLength', Config.DIRECT_DOWNLOAD_LIMIT)
@@ -443,7 +445,7 @@ def direct_download_url(path, bucket_name=Config.DEFAULT_S3_BUCKET_NAME):
 
     response = s3.get_object(
         Bucket=s3BucketName,
-        Key=path,
+        Key=s3_path,
         RequestPayer="requester"
     )
 

--- a/app/manifest_name_to_discover_name.py
+++ b/app/manifest_name_to_discover_name.py
@@ -5008,5 +5008,7 @@ name_map = {'files/primary/sub-PR1705/pool-PR1705/PR1705_Blockface_1-531_Shaina-
             'files/primary/sub-Cadaver-Subject-2/Ultrasound_raw_Cadaver_Subject 2.mp4': 'files/primary/sub-Cadaver-Subject-2/Ultrasound_raw_Cadaver_Subject_2.mp4',
             'files/primary/sub-Cadaver-Subject-3/Ultrasound_raw_Cadaver_Subject 3.mp4': 'files/primary/sub-Cadaver-Subject-3/Ultrasound_raw_Cadaver_Subject_3.mp4',
             'files/derivative/sam-P21 BAT/ses-Pgp9.5/P21-3_Pgp9.5.jpx': 'files/derivative/sam-P21 BAT/ses-Pgp9.5/P21-3 Pgp9.5.jpx',
-            'files/derivative/sam-P21 BAT/ses-Pgp9.5/P21-4_Pgp9.5.jpx': 'files/derivative/sam-P21 BAT/ses-Pgp9.5/P21-4 Pgp9.5.jpx'
+            'files/derivative/sam-P21 BAT/ses-Pgp9.5/P21-4_Pgp9.5.jpx': 'files/derivative/sam-P21 BAT/ses-Pgp9.5/P21-4 Pgp9.5.jpx',
+            'files/derivative/mapped_Pig 7_thumbnail.jpeg': 'files/derivative/mapped_Pig_7_thumbnail.jpeg',
+            'files/derivative/mapped_Pig 16_thumbnail.jpeg': 'files/derivative/mapped_Pig_16_thumbnail.jpeg'
 }

--- a/app/utilities.py
+++ b/app/utilities.py
@@ -1,6 +1,18 @@
 import base64
 from io import BytesIO
+from app.manifest_name_to_discover_name import name_map
 
+def check_path_in_mangled_list(s3_path):
+
+    # Split out the file part of the path
+    s3_paths = s3_path.split('files/')
+    s3_paths[1] = 'files/' + s3_paths[1]  # Add the part we split on back
+
+    # Switch the path to the mapped one if it is listed
+    if s3_paths[1] in name_map:
+        s3_paths[1] = name_map[s3_paths[1]]
+
+    return s3_paths[0] + s3_paths[1]  # Return the path with dataset info at the front
 
 def img_to_base64_str(img):
     """

--- a/app/utilities.py
+++ b/app/utilities.py
@@ -2,17 +2,14 @@ import base64
 from io import BytesIO
 from app.manifest_name_to_discover_name import name_map
 
-def check_path_in_mangled_list(s3_path):
+def get_path_from_mangled_list(s3_path):
 
     # Split out the file part of the path
     s3_paths = s3_path.split('files/')
-    s3_paths[1] = 'files/' + s3_paths[1]  # Add the part we split on back
+    file_path = 'files/' + s3_paths[1]  # Add the part we split on back
 
     # Switch the path to the mapped one if it is listed
-    if s3_paths[1] in name_map:
-        s3_paths[1] = name_map[s3_paths[1]]
-
-    return s3_paths[0] + s3_paths[1]  # Return the path with dataset info at the front
+    return s3_paths[0] + name_map.get(file_path, file_path)
 
 def img_to_base64_str(img):
     """

--- a/tests/test_dataset_info.py
+++ b/tests/test_dataset_info.py
@@ -2,6 +2,8 @@ import json
 import pytest
 from app import app
 
+from app.config import Config
+
 from timeit import default_timer as timer
 
 from app.scicrunch_processing_common import SCAFFOLD_FILE, PLOT_FILE, COMMON_IMAGES, THUMBNAIL_IMAGE, NAME, BIOLUCIDA_3D, VIDEO, SEGMENTATION_FILES, BIOLUCIDA_2D
@@ -279,3 +281,19 @@ def test_name_mangling_for_s3_resource(client):
     # to check the name mangling code is working
     r = client.get('/s3-resource/328/1/files/derivative/mapped_Pig%207_thumbnail.jpeg?s3BucketName=prd-sparc-discover-use1')
     assert r.status_code == 200
+
+def test_size_limit_on_mangled_s3_resource(client):
+    # This test checks that files that are mangled and too large will return a 413
+
+    config_download_limit = Config.DIRECT_DOWNLOAD_LIMIT  # Store download limit
+    Config.DIRECT_DOWNLOAD_LIMIT = 20  # set limit to 20 bytes to force a 413
+
+    # Use a try-except to make sure we can set the limit back
+    try:
+        r = client.get('/s3-resource/328/1/files/derivative/mapped_Pig%207_thumbnail.jpeg?s3BucketName=prd-sparc-discover-use1')
+    except:
+        pass
+
+    Config.DIRECT_DOWNLOAD_LIMIT = config_download_limit  # set limit back
+
+    assert r.status_code == 413  # Check we got the correct response

--- a/tests/test_dataset_info.py
+++ b/tests/test_dataset_info.py
@@ -273,3 +273,9 @@ def test_pennsieve_identifier_dataset_search(client):
     print(first_result)
     for r in result[BIOLUCIDA_3D]:
         print(r['dataset']['path'])
+
+def test_name_mangling_for_s3_resource(client):
+    # This test uses a file on dataset 328 which has a file where space is converted to underscore
+    # to check the name mangling code is working
+    r = client.get('/s3-resource/328/1/files/derivative/mapped_Pig%207_thumbnail.jpeg?s3BucketName=prd-sparc-discover-use1')
+    assert r.status_code == 200


### PR DESCRIPTION
# Description

Added a check of the mangled name list to the s3-resource endpoint.

Note that this check only occurs if the following conditions are satisfied:
 1. s3 returns 404 for the resource
 2. The file is contained in the file name map for mangling

If these checks are true, the resource is downloaded with the modified name

This is needed as some parts of the /maps page use this endpoint to fetch files which have mangled file paths

Can reproduce this bug by going to this url:
https://sparc-api.herokuapp.com/s3-resource/328/1/files/derivative/mapped_Pig%207_thumbnail.jpeg?s3BucketName=prd-sparc-discover-use1

![image](https://github.com/nih-sparc/sparc-api/assets/37255664/b9bec204-3b93-4d8a-8f92-eeb8a7a25cda)


Notice how the name matches what we see on pennsieve and sparc.science, but we must modify the path to find it on s3

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Tested locally with sparc-app and passed all tests


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
