### PR TITLE
Add contextinfo to get_body_scaffold_info endpoint's response.

### DIFF
--- a/app/scicrunch_process_results.py
+++ b/app/scicrunch_process_results.py
@@ -80,10 +80,13 @@ def process_get_first_scaffold_info(results):
         if 'abi-scaffold-metadata-file' in result and len(result['abi-scaffold-metadata-file']) > 0:
             try:
                 path = result['abi-scaffold-metadata-file'][0]['dataset']['path']
+                context_info = ''
+                if len(result['abi-context-file']) > 0:
+                    context_info = result['abi-context-file'][0]['dataset']['path']
                 id = result['dataset_identifier']
                 version = result['dataset_version']
                 s3uri = result['s3uri']
-                return jsonify({'path':path, 'id': id, 'version': version, 's3uri': s3uri})
+                return jsonify({'path':path, 'id': id, 'version': version, 's3uri': s3uri, 'contextinfo': context_info})
             except KeyError:
                 return None
 

--- a/tests/test_scicrunch.py
+++ b/tests/test_scicrunch.py
@@ -431,6 +431,7 @@ def test_get_body_scaffold_info(client):
     result = json.loads(r.data)
     assert result['id'] == '307'
     assert result['path'] == 'derivative/human_body_metadata.json'
+    assert result['contextinfo'] == 'derivative/scaffold_context_info.json'
     assert 'prd-sparc-discover-use1' in result['s3uri']
 
 def test_getting_curies(client):


### PR DESCRIPTION
# Description

Add a link to contextual information to the response with the get_body_scaffold_info api.

## Type of change

Delete those that don't apply.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested locally.


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
