### PR TITLE
oSPARC: need to account for the release of the new Web API

### DIFF
--- a/app/osparc/osparc.py
+++ b/app/osparc/osparc.py
@@ -152,12 +152,10 @@ def check_simulation(data):
         solver_version = data["solver"]["version"]
         status = solvers_api.inspect_job(solver_name, solver_version, job_id)
 
-        if status.state in {"SUCCESS", "FAILED"}:
-            # The simulation has completed, but was it successful?
+        if status.state == "FAILED":
+            raise SimulationException("the simulation failed")
 
-            if status.state == "FAILED":
-                raise SimulationException("the simulation failed")
-
+        if status.state == "SUCCESS":
             # Retrieve the simulation job outputs.
 
             try:

--- a/app/osparc/osparc.py
+++ b/app/osparc/osparc.py
@@ -152,10 +152,10 @@ def check_simulation(data):
         solver_version = data["solver"]["version"]
         status = solvers_api.inspect_job(solver_name, solver_version, job_id)
 
-        if status.progress == 100:
+        if status.state in {"SUCCESS", "FAILED"}:
             # The simulation has completed, but was it successful?
 
-            if status.state != "SUCCESS":
+            if status.state == "FAILED":
                 raise SimulationException("the simulation failed")
 
             # Retrieve the simulation job outputs.


### PR DESCRIPTION
# Description

Following the release of the new Web API, our `/check_simulation` endpoint is not always able to determine the end of a simulation. Thus, for datasets 135, 157, and 308, everything is fine, but for datasets 318 and 320, we get an error message that reads that `the simulation failed` even though it is actually successful.


## Type of change

Delete those that don't apply.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

I tested it using my local fixed copy of the SPARC API and the Simulation viewer standalone app and this for datasets 135, 157, 308, 318, and 320.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added unit tests that prove my fix is effective or that my feature works

Fixes #190.
