### PR TITLE
Removed unnecessary decode

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -344,7 +344,7 @@ def extract_thumbnail_from_xml_file(bucket_name=Config.DEFAULT_S3_BUCKET_NAME):
             else:
                 return abort(404, description=f"Unknown error for file: '{path}'")
 
-        resource = response["Body"].read().decode('UTF-8')
+        resource = response["Body"].read()
         start_tag_found = '<thumbnail ' in resource
         end_tag_found = '</thumbnail>' in resource
         if start_tag_found and not end_tag_found:
@@ -610,7 +610,7 @@ def get_segmentation_info_from_file(bucket_name=Config.DEFAULT_S3_BUCKET_NAME):
         else:
             return abort(404, description=f"Unknown error for file: '{dataset_path}'")
 
-    resource = response["Body"].read().decode('UTF-8')
+    resource = response["Body"].read()
     xml = ElementTree.fromstring(resource)
     subject_element = xml.find('./{*}sparcdata/{*}subject')
     info = {}


### PR DESCRIPTION
# Description

Decode was throwing errors for files that did not have UTF-8 Encoding (i.e. https://staging.sparc.science/datasets/file/226/2?path=files%2Fprimary%2Fsub-131%2Fsam-11%2F131L_F5.xml if you inspect the file you will see that it uses ISO-8859-1 encoding) and was therefore not displaying the viewer. Testing out the changes, we do not need to decode the file
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
