### PR TITLE
Added back decode to thumbnail segmentation route

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -344,7 +344,7 @@ def extract_thumbnail_from_xml_file(bucket_name=Config.DEFAULT_S3_BUCKET_NAME):
             else:
                 return abort(404, description=f"Unknown error for file: '{path}'")
 
-        resource = response["Body"].read()
+        resource = response["Body"].read().decode('UTF-8')
         start_tag_found = '<thumbnail ' in resource
         end_tag_found = '</thumbnail>' in resource
         if start_tag_found and not end_tag_found:


### PR DESCRIPTION
# Description

Not sure if this is necessary still, but since it broke the following test: 

    tests/test_thumbnails.py::test_segmentation_thumbnail

I figured I should add it back


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
