### PR TITLE
Fix a dictionary evaluation error in monthly stats

### DIFF
--- a/scripts/monthly_stats.py
+++ b/scripts/monthly_stats.py
@@ -149,12 +149,14 @@ class MonthlyStats(object):
             for contributor in dataset['contributors']:
                 orcid_id = contributor['orcid']
 
-                # Add the download info with an orcid id as a key
-                if orcid_id not in users.keys():
-                    users[orcid_id] = {}
-                    users[orcid_id]['datasets'] = downloadInfo
-                else:
-                    users[orcid_id]['datasets'] += downloadInfo
+                if orcid_id is not None:
+                    # Add the download info with an orcid id as a key
+                    if orcid_id not in users.keys():
+                        users[orcid_id] = {}
+                        users[orcid_id]['datasets'] = downloadInfo
+                    else:
+                        # Must to a dictionary 'get' below, as using += mutates the dictionary
+                        users[orcid_id]['datasets'] = users.get(orcid_id)['datasets'] + downloadInfo
 
         return users
 


### PR DESCRIPTION
# Description

I didn't realise until now as Sue noticed she had far too many datasets in her monthly stats, but there was an issue when using the += operator on a dictionary key where it would sometimes add the value to multiple keys. 

Because of this issue, some users were getting massive lists of datasets in their monthly dataset update.

My apologies for this, I didn't know this operator had strange behavior on dictionaries in python.

This fix removes the usage and the stats now generated are correct for the use case I was using ( orcidId: 0000-0001-5120-3770 ) and the others I looked at


## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Ran the monthly stats tests and manually checked orcid Id against pennsieve listed datasets to ensure the correct datasets are coming up for them


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
