### PR TITLE
Captcha validation for /tasks endpoint

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -86,3 +86,5 @@ class Config(object):
     CTF_CMA_ACCESS_TOKEN = os.environ.get("CTF_CMA_ACCESS_TOKEN")
     CTF_SPACE_ID = os.environ.get("CTF_SPACE_ID")
     CTF_HOMEPAGE_ID = os.environ.get("CTF_HOMEPAGE_ID", '4qJ9WUWXg09FAUvCnbGxBY')
+    NUXT_TURNSTILE_SECRET_KEY = os.environ.get("NUXT_TURNSTILE_SECRET_KEY")
+    TURNSTILE_URL = os.environ.get("TURNSTILE_URL", "https://challenges.cloudflare.com/turnstile/v0/siteverify")

--- a/app/main.py
+++ b/app/main.py
@@ -1050,6 +1050,20 @@ def get_scaffold_state():
 @app.route("/tasks", methods=["POST"])
 def create_wrike_task():
     form = request.form
+    if "captcha_token" in form:
+        captchaReq = requests.post(
+            url=Config.TURNSTILE_URL,
+            json={
+                "secret": Config.NUXT_TURNSTILE_SECRET_KEY,
+                "response": form["captcha_token"]
+            }
+        )
+        captchaResp = captchaReq.json()
+        if "success" not in captchaResp or not captchaResp["success"]:
+            abort(409, description="Failed Captcha Validation")
+    else:
+        abort(409, description="Missing Captcha Token")
+    # captcha all good
     if form and 'title' in form and 'description' in form:
         title = form["title"]
         description = form["description"]


### PR DESCRIPTION
# Description

Captcha validation is not done in the same `tasks`endpoint before processing the data


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Manually


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
