### PR TITLE
switch monthly stats send to it's own envvar

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -72,6 +72,7 @@ class Config(object):
     SCI_CRUNCH_SCIGRAPH_HOST = os.environ.get("SCI_CRUNCH_SCIGRAPH_HOST", "https://scicrunch.org/api/1/sparc-scigraph")
     SENDGRID_API_KEY =  os.environ.get("SENDGRID_API_KEY")
     SENDGRID_MONTHLY_STATS_UNSUBSCRIBE_GROUP = os.environ.get("SENDGRID_MONTHLY_STATS_UNSUBSCRIBE_GROUP", '')
+    SEND_MONTHLY_STATS = os.environ.get("SEND_MONTHLY_STATS", "FALSE")
     README_API_KEY =  os.environ.get("README_API_KEY")
     # Metrics
     GOOGLE_API_GA_SCOPE = os.environ.get("GOOGLE_API_GA_SCOPE", "https://www.googleapis.com/auth/analytics.readonly")

--- a/scripts/monthly_stats.py
+++ b/scripts/monthly_stats.py
@@ -172,7 +172,7 @@ class MonthlyStats(object):
                                                                     email_destination,
                                                                     'SPARC monthly dataset download summary',
                                                                     email_body)
-        elif Config.DEPLOY_ENV == 'production':
+        elif Config.SEND_MONTHLY_STATS == 'TRUE':
             email_destination = email_address
             return self.send_grid.sendgrid_email_with_unsubscribe_group(Config.METRICS_EMAIL_ADDRESS,
                                                                     email_destination,


### PR DESCRIPTION
# Description

There were reports of duplicate monthly stats recently. I realised this is likely because sparc-api running _anywhere_ with `DEPLOY_ENV ` set to 'production', the emails will send at the end of the month. 

This separate environment variable will ensure stats aren't sent while running other parts of the site

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works
