### PR TITLE
Added a new endpoint (`/pmr_file`) to download a PMR-based file

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -89,3 +89,4 @@ class Config(object):
     CTF_HOMEPAGE_ID = os.environ.get("CTF_HOMEPAGE_ID", '4qJ9WUWXg09FAUvCnbGxBY')
     NUXT_TURNSTILE_SECRET_KEY = os.environ.get("NUXT_TURNSTILE_SECRET_KEY")
     TURNSTILE_URL = os.environ.get("TURNSTILE_URL", "https://challenges.cloudflare.com/turnstile/v0/siteverify")
+    PMR_HOST = os.environ.get("PMR_HOST", "https://models.physiomeproject.org")

--- a/app/main.py
+++ b/app/main.py
@@ -1380,6 +1380,22 @@ def simulation_ui_file(identifier):
         abort(404, description="no simulation UI file could be found")
 
 
+@app.route("/pmr_file", methods=["POST"])
+def pmr_file():
+    data = request.get_json()
+    if data and "path" in data:
+        try:
+            resp = requests.post(f"{Config.PMR_HOST}/{data['path']}")
+            if resp.status_code == 200:
+                return base64.b64encode(resp.content)
+            else:
+                return resp.json()
+        except:
+            abort(400, description="invalid path")
+    else:
+        abort(400, description="missing path")
+
+
 @app.route("/start_simulation", methods=["POST"])
 def start_simulation():
     data = request.get_json()

--- a/app/main.py
+++ b/app/main.py
@@ -1083,7 +1083,7 @@ def create_wrike_task():
         title = form["title"]
         description = form["description"]
         newTaskDescription = form["description"]
-        
+
         hed = { 'Authorization': 'Bearer ' + Config.WRIKE_TOKEN }
         ## Updated Wrike Space info based off type of task. We default to drc_feedback folder if type is not present.
         url = 'https://www.wrike.com/api/v4/folders/' + Config.DRC_FEEDBACK_FOLDER_ID + '/tasks'

--- a/tests/test_pmr.py
+++ b/tests/test_pmr.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 from app import app
 
@@ -7,6 +6,26 @@ from app import app
 def client():
     app.config['TESTING'] = True
     return app.test_client()
+
+
+def test_pmr_file(client):
+    r = client.get('/pmr_file')
+    assert r.status_code == 405
+
+
+def test_pmr_file_empty_post(client):
+    r = client.post("/pmr_file", json={})
+    assert r.status_code == 400
+
+
+def test_pmr_file_valid_path(client):
+    r = client.post("/pmr_file", json={"path": "workspace/486/rawfile/55879cbc485e2d4c41f3dc6d60424b849f94c4ee/HumanSAN_Fabbri_Fantini_Wilders_Severi_2017.cellml"})
+    assert r.status_code == 200
+
+
+def test_pmr_file_invalid_path(client):
+    r = client.post("/pmr_file", json={"path": "invalid_path"})
+    assert r.status_code == 400
 
 
 def test_pmr_latest_exposure_no_post(client):

--- a/tests/test_pmr.py
+++ b/tests/test_pmr.py
@@ -54,5 +54,4 @@ def test_pmr_latest_exposure_workspace_without_latest_exposure(client):
 
 def test_pmr_latest_exposure_workspace_with_invalid_workspace_url(client):
     r = client.post("/pmr_latest_exposure", json={"workspace_url": "https://some.url.com/"})
-    print(r.get_json())
     assert r.status_code == 400


### PR DESCRIPTION
# Description

We want to be able to download a file from [PMR](https://models.physiomeproject.org/welcome). We therefore added a new endpoint: `/pmr_file`. This allows to download any file under [https://models.physiomeproject.org/](https://models.physiomeproject.org).

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Some tests have been tested. This has also been tested using `SimulationVuer`'s demo app.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added unit tests that prove my fix is effective or that my feature works
