### PR TITLE
Tweak project overview, link to python client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Overview
-This is the API service which is build as a Flask Application. It runs independent of the Nuxt.js web-application.
+This is the SPARC Portal API service which is built as a Flask Application. It runs independent of the [Nuxt.js web-application](https://github.com/nih-sparc/sparc-app-2).
+
+If you are looking for a Python client to use for accessing and using SPARC resources, please see [Python client for NIH SPARC](https://github.com/nih-sparc/sparc.client).
+
 # Requirements
 
 ## Python 3


### PR DESCRIPTION
# Description

Tweaking the project overview in the README to distinguish between the sparc-api and the SPARC Python client. Also providing a link to the Python client.

First attempt at fixing #223.

## Type of change

Delete those that don't apply.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Changes to README only.


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
