### PR TITLE
Added file size check to segmentation info endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -613,6 +613,11 @@ def get_segmentation_info_from_file(bucket_name=Config.DEFAULT_S3_BUCKET_NAME):
     dataset_path = query_args.get('dataset_path')
 
     try:
+        # Check the header to see if too large
+        response = s3_header_check(dataset_path, s3BucketName)
+        # Check if file exists
+        if response[0] == 404:
+            abort(404, description=f'Provided path was not found on the s3 resource')
         response = s3.get_object(
             Bucket=s3BucketName,
             Key=dataset_path,


### PR DESCRIPTION
# Description

Added file size check so that we do not crash the server when calling with a file over 20 MB

## Type of change

Delete those that don't apply.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally via /segmentation_info?dataset_path=293%2Ffiles%2Fderivative%2Fsub-1Pet1Flp-Tac1Cre-RCPFTox%2Fsam-3ileum%2F211208_PFtox_ile.tif&s3BucketName=prd-sparc-discover50-use1

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
