### PR TITLE
Added timeout along with exception handlers to neurolucida host endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -319,14 +319,14 @@ def thumbnail_from_neurolucida_file():
         if response.status_code == 200:
             if response.headers.get('Content-Type', 'unknown') == 'image/png':
                 return base64.b64encode(response.content)
+        abort(400, 'Failed to retrieve thumbnail.')
+    
     except requests.exceptions.ConnectionError:
         return abort(400, description="Unable to make a connection to NEUROLUCIDA_HOST.")
     except requests.exceptions.Timeout:
         return abort(504, 'Request to NEUROLUCIDA_HOST timed out.')
     except requests.exceptions.RequestException as e:
         return abort(502, f"Error while requesting NEUROLUCIDA_HOST: {str(e)}")
-
-    abort(400, 'Failed to retrieve thumbnail.')
 
 
 @app.route("/thumbnail/segmentation")

--- a/app/main.py
+++ b/app/main.py
@@ -313,10 +313,18 @@ def thumbnail_from_neurolucida_file():
         return abort(400, description=f"Query arguments are not valid.")
 
     url = f"{Config.NEUROLUCIDA_HOST}/thumbnail"
-    response = requests.get(url, params=query_args)
-    if response.status_code == 200:
-        if response.headers.get('Content-Type', 'unknown') == 'image/png':
-            return base64.b64encode(response.content)
+    try:    
+        response = requests.get(url, params=query_args, timeout=5)
+        response.raise_for_status()
+        if response.status_code == 200:
+            if response.headers.get('Content-Type', 'unknown') == 'image/png':
+                return base64.b64encode(response.content)
+    except requests.exceptions.ConnectionError:
+        return abort(400, description="Unable to make a connection to NEUROLUCIDA_HOST.")
+    except requests.exceptions.Timeout:
+        return abort(504, 'Request to NEUROLUCIDA_HOST timed out.')
+    except requests.exceptions.RequestException as e:
+        return abort(502, f"Error while requesting NEUROLUCIDA_HOST: {str(e)}")
 
     abort(400, 'Failed to retrieve thumbnail.')
 


### PR DESCRIPTION
# Description

Added exception handling to neurolucida endpoint in case Neurolucida server is down and connection cannot be made. Also added a timeout so that it will not hold up the Flask worker while waiting for the external server to respond.

## Type of change

Delete those that don't apply.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Verified that it stops the Flask app from crashing when Neurolucida is down

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
