### PR TITLE
Fix an error on email sorting.

### DIFF
--- a/scripts/monthly_stats.py
+++ b/scripts/monthly_stats.py
@@ -15,6 +15,7 @@ def remove_duplicates(d_array):
     json_list = [json.dumps(d) for d in d_array]
     json_set = set(json_list)
     unique_list = [json.loads(d) for d in json_set]
+    unique_list = sorted(unique_list, key=itemgetter("datasetId", "version"), reverse=True)
     return unique_list
 
 
@@ -132,9 +133,7 @@ class MonthlyStats(object):
                 orcid_id = user['orcid']['orcid']
                 if orcid_id in self.user_stats.keys():
                     self.user_stats[orcid_id]['email'] = user['email']
-                    datasets = self.user_stats[orcid_id]['datasets']
-                    self.user_stats[orcid_id]['datasets'] = \
-                        sorted(datasets, key=itemgetter("datasetId", "version"), reverse=True)
+                    self.user_stats[orcid_id]['datasets'] = self.user_stats[orcid_id]['datasets']
 
     # Get details for a given metrics object
     def get_dataset_details_from_pennsieve(self, metrics):


### PR DESCRIPTION
# Description

After running more testing on the monthly stats sender, I found a bug on the [previous implementation](https://github.com/nih-sparc/sparc-api/pull/233) on monthly stats datasets sorting. This commit will fix the issue.

[Wrike ticket.](https://www.wrike.com/open.htm?id=1467992696)

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

I have ran more tests and export the html on the email body to double check.
I have attached a screenshot with how the html block would look in the email with the correct sorting order.
![image](https://github.com/user-attachments/assets/ff7a93bd-05c5-4afe-a19d-69111db3248a)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
