### PR TITLE
bump requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ pymongo==3.8.0
 python-dateutil==2.8.0
 python-dotenv==0.10.3
 query-string==2019.4.13
-requests==2.25.1
+requests==2.31.0
 s3transfer==0.4.2
 sendgrid==6.9.7
 six==1.13.0


### PR DESCRIPTION
# Description

hubspot api client requires requests version 2.31.0 or greater
