### PR TITLE
Set pool_pre_ping to true for database connection

### DIFF
--- a/app/dbtable.py
+++ b/app/dbtable.py
@@ -27,7 +27,7 @@ class FeaturedDatasetIdSelectorState(base):
 
 class Table:
   def __init__(self, databaseURL, state):
-        db = create_engine(databaseURL)
+        db = create_engine(databaseURL, pool_pre_ping=True)
         global base
         base.metadata.create_all(db)
         Session = sessionmaker(db)
@@ -66,12 +66,12 @@ class Table:
   def pullState(self, id):
     try:
         result = self._session.query(self._state).filter_by(uuid=id).first()
+        if result:
+            return result.data
     except SQLAlchemyError:
         self._session.rollback()
-    if result:
-        return result.data
-    else:
-        return None
+    return None
+
 
 class MapTable(Table):
     def __init__(self, databaseURL):


### PR DESCRIPTION
# Description

I have started seeing more connection issues when accessing the database on heroku recently with the following summary -
`Dec 03 03:07:16 PM [sparc-api-prod](https://my.na-01.cloud.solarwinds.com/218242196097690624/logs?q=host%3A%22sparc-api-prod%22&focus=1800423504874549301&selected=1800423504874549301) [app/web.1](https://my.na-01.cloud.solarwinds.com/218242196097690624/logs?q=program%3A%22app%2Fweb.1%22&focus=1800423504874549301&selected=1800423504874549301) (Background on this error at: http://sqlalche.me/e/13/e3q8)`

Setting pool_pre_ping to true when creating the sqlalchemy engine may help to stabilize the connections. See more information [here](https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic). The flag essentially making sure a simple request is used to ping the db before making the actual request, if any issue is found the engine will recyle the connection.

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have tested this with my local APIs and database.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
