### PR TITLE
upgraded dependencies

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -87,21 +87,24 @@ s3 = boto3.client(
 
 biolucida_lock = Lock()
 
+db_url = Config.DATABASE_URL
+if db_url and db_url.startswith("postgres://"):
+    db_url = db_url.replace("postgres://", "postgresql://", 1)
+
 try:
-    maptable = MapTable(Config.DATABASE_URL)
+    maptable = MapTable(db_url)
 except AttributeError:
     maptable = None
 
 try:
-    scaffoldtable = ScaffoldTable(Config.DATABASE_URL)
+    scaffoldtable = ScaffoldTable(db_url)
 except AttributeError:
     scaffoldtable = None
 
 try:
-    featuredDatasetIdSelectorTable = FeaturedDatasetIdSelectorTable(Config.DATABASE_URL)
+    featuredDatasetIdSelectorTable = FeaturedDatasetIdSelectorTable(db_url)
 except AttributeError:
     featuredDatasetIdSelectorTable = None
-
 
 class Biolucida(object):
     _token = ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ osparc==0.4.3
 Pennsieve==6.1.1
 Pennsieve2==0.1.2
 Pillow
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.10
 public==2019.4.13
 pytest
 pymongo==3.8.0
@@ -39,6 +39,6 @@ requests==2.31.0
 s3transfer==0.6.0
 sendgrid==6.9.7
 six==1.13.0
-SQLAlchemy==1.3.20
+SQLAlchemy==2.0.40
 urllib3==1.26.4
 Werkzeug==0.16.0

--- a/scripts/monthly_stats.py
+++ b/scripts/monthly_stats.py
@@ -35,7 +35,10 @@ class MonthlyStats(object):
             self.logging_address = Config.METRICS_EMAIL_ADDRESS
         if Config.DATABASE_URL is not None:
             try:
-                self.monthlytable = MonthlyStatsTable(Config.DATABASE_URL)
+                db_url = Config.DATABASE_URL
+                if db_url and db_url.startswith("postgres://"):
+                    db_url = db_url.replace("postgres://", "postgresql://", 1)
+                self.monthlytable = MonthlyStatsTable(db_url)
             except AttributeError:
                 self.monthlytable = None
 


### PR DESCRIPTION
# Description

Upgraded psycopg2-binary and sqlalchemy dependencies. New version of  SQLAlchemy doesn’t recognize postgres as a valid dialect. The correct dialect string is postgresql, not postgres. Heroku gives you a postgres://... URL by default, but SQLAlchemy requires postgresql:// and you cannot update the env var. Instead you must patch it like shown in changes

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
