### PR TITLE
Added uuids endpoint for dashboard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ import atexit
 from app.metrics.pennsieve import get_download_count
 from app.metrics.contentful import init_cf_cda_client, get_funded_projects_count, get_featured_datasets
 from scripts.update_contentful_entries import update_all_events_sort_order, update_event_sort_order
-from app.metrics.algolia import get_dataset_count, init_algolia_client, get_all_dataset_ids, get_associated_datasets
+from app.metrics.algolia import get_dataset_count, init_algolia_client, get_all_dataset_ids, get_all_dataset_uuids, get_associated_datasets
 from app.metrics.ga import init_ga_reporting, get_ga_1year_sessions, init_gspread_client, append_contact, upload_file, init_drive_client
 from scripts.update_featured_dataset_id import set_featured_dataset_id, get_featured_dataset_id_table_state
 from scripts.update_protocol_metrics import update_protocol_metrics, get_protocol_metrics_table_state
@@ -2299,10 +2299,18 @@ def event_updated():
         else:
             abort(400, description="Missing event data")
 
-
+@cache.cached(timeout=86400)
 @app.route("/all_dataset_ids", methods=["GET"])
 def all_dataset_ids():
     list = get_all_dataset_ids()
+    string_list = [str(element) for element in list]
+    delimiter = ", "
+    return delimiter.join(string_list)
+
+@cache.cached(timeout=86400)
+@app.route("/all_dataset_uuids", methods=["GET"])
+def all_dataset_uuids():
+    list = get_all_dataset_uuids()
     string_list = [str(element) for element in list]
     delimiter = ", "
     return delimiter.join(string_list)

--- a/app/metrics/algolia.py
+++ b/app/metrics/algolia.py
@@ -30,6 +30,15 @@ def get_all_dataset_ids():
       object_ids.append(record['objectID'])
   return object_ids
 
+def get_all_dataset_uuids():
+  client = init_algolia_client()
+  index = client.init_index(INDEX)
+  uuids = []
+  for record in index.browse_objects():
+    if record.get('item') and record['item'].get('identifier'):
+      uuids.append(record['item']['identifier'])
+  return uuids
+
 def get_associated_datasets(projectId):
   client = init_algolia_client()
   index = client.init_index(INDEX)


### PR DESCRIPTION
# Description

Added endpoint to retreive all datasets uuids in algolia's sparc index. This is needed in order to check uuids returned from the QDB to filter out test data

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

