### PR TITLE
Added a safety check for encoded file to be a string instead of bytes

### DIFF
--- a/scripts/email_sender.py
+++ b/scripts/email_sender.py
@@ -150,6 +150,8 @@ class EmailSender(object):
         return response
 
     def mailersend_email_with_attachment(self, from_email, to, subject, body, encoded_file, file_name, file_type):
+        if isinstance(encoded_file, bytes):
+          encoded_file = encoded_file.decode("utf-8")
         attachment = {
             "content": encoded_file,
             "filename": file_name,


### PR DESCRIPTION
# Description

Kind of a shot in the dark as everything runs fine locally, but somehow the encoded file is getting interpreted as bytes instead of a string even after calling .decode(utf-8). Just added a safety check to see if this will fix it

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Locally, but it has been running fine locally anyways


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
