### PR TITLE
Add attachment name to response

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1828,6 +1828,7 @@ def report_form_submission():
     request_response = {
       "message": "Request successfully submitted. ",
       "status": "success",
+      "attachment_filename": ""
     }
     request_response_code = 201
 
@@ -1847,6 +1848,7 @@ def report_form_submission():
     description = form["description"]
     if has_attachment and file_upload_response and file_upload_response['webViewLink']:
         description += "\n\nAttachment: " + file_upload_response['webViewLink']
+        request_response["attachment_filename"] = image_id
     description = description.replace("\r\n", "\n").replace("\n", "<br>")
     # --- Save to Google Sheets ---
     try:


### PR DESCRIPTION
# Description

In order to satisfy the failing test (so that the test can clean up the excel sheet), the response must return the attachment name

## Type of change

- [X] Failing test


# How Has This Been Tested?

Locally


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
