### PR TITLE
Return doi and path for out of date doi request.

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -709,7 +709,7 @@ def get_is_derived_from_with_identifier_or_path(discoverId, version, objects, id
                 for i in range(len(derivedfromdatasetdoi)):
                     if 0 <= i < len(derivedfromdatasetpath):
                         doi = derivedfromdatasetdoi[i].replace('https://doi.org/', '')
-                        source_list.extend(get_original_source(None, doi, None, derivedfromdatasetpath[i], datasetCache))
+                        source_list.extend(get_original_source(None, doi, None, derivedfromdatasetpath[i], datasetCache, True))
 
     return source_list
 
@@ -727,8 +727,7 @@ def get_original_source_in_dataset(dataset_info, identifier, matchingPath, datas
             return get_is_derived_from_with_identifier_or_path(discoverId, version, objects, identifier, matchingPath, datasetCache)
     return []
 
-
-def get_original_source(identifier, doi, discoverId, path, datasetCache):
+def get_original_source(identifier, doi, discoverId, path, datasetCache, fromDerived = False):
     query = None
     id = identifier
     if identifier is not None:
@@ -745,6 +744,10 @@ def get_original_source(identifier, doi, discoverId, path, datasetCache):
     if dataset_info is None:
         dataset_info = dataset_search(query)
         datasetCache[id] = dataset_info
+    hits = dataset_info.get('hits', {}).get('hits', [])
+    if len(hits) == 0 and fromDerived and doi and path:
+        return [{ "doi": doi, "path": path }]
+
     return get_original_source_in_dataset(dataset_info, identifier, path, datasetCache)
 
 

--- a/tests/test_dataset_info.py
+++ b/tests/test_dataset_info.py
@@ -225,9 +225,10 @@ def test_get_original_source_from_external_id_and_path(client):
     assert len(response['result']) > 0
     found = 0
     for item in response['result']:
-        if item['discoverId'] == '438':
+        print(item)
+        if item.get('discoverId', '') == '438' or item.get('doi', '') == '10.26275/ugoe-ccnw':
             found = found + 1
-    assert found > 0
+    assert found > 1
 
 def test_title_plot_annotation_dataset_search(client):
     print()


### PR DESCRIPTION
# Description

This will resolve the issue described here https://github.com/nih-sparc/sparc-app-issues/issues/918, it will return the doi and path instead which can be used to resolve to actual url  by the front end.

## Type of change

Delete those that don't apply.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

I have updated the test and it is working correctly.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests that prove my fix is effective or that my feature works
