### PR TITLE
SciCrunch resolver

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -53,6 +53,7 @@ class Config(object):
     SCI_CRUNCH_SCIGRAPH_HOST = os.environ.get("SCI_CRUNCH_SCIGRAPH_HOST", "https://scicrunch.org/api/1/sparc-scigraph")
     SCI_CRUNCH_CITATIONS_HOST = os.environ.get("SCI_CRUNCH_CITATIONS_HOST", "https://api.scicrunch.io/elastic/v2/SPARC_Citations_pr")
     SCI_CRUNCH_QDB_HOST = os.environ.get("SCI_CRUNCH_QDB_HOST", "https://services.scicrunch.io/quantdb/api/1/values")
+    SCI_CRUNCH_RESOLVER_HOST = os.environ.get("SCI_CRUNCH_RESOLVER_HOST", "https://scicrunch.org/resolver")
     HUBSPOT_API_TOKEN = os.environ.get("HUBSPOT_API_TOKEN")
     HUBSPOT_CLIENT_SECRET = os.environ.get("HUBSPOT_CLIENT_SECRET")
     EMAIL_OCTOPUS_API_KEY = os.environ.get("EMAIL_OCTOPUS_API_KEY")

--- a/app/main.py
+++ b/app/main.py
@@ -558,6 +558,25 @@ def sci_doi(doi1, doi2):
         return json.dumps({'error': err})
 
 
+# /scicrunch/resolver/<rrid>: Proxies requests to the SciCrunch resolver API
+@app.route("/scicrunch/resolver/<path:rrid>")
+def sci_resolver(rrid):
+    try:
+        response = requests.get(
+            f'{Config.SCI_CRUNCH_RESOLVER_HOST}/{rrid}.json',
+            timeout=30
+        )
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.ConnectionError:
+        return jsonify({'error': 'Unable to connect to SciCrunch resolver'}), 502
+    except requests.exceptions.Timeout:
+        return jsonify({'error': 'Request to SciCrunch resolver timed out'}), 504
+    except requests.exceptions.RequestException as err:
+        logging.error(err)
+        return jsonify({'error': str(err)}), 502
+
+
 # /pubmed/<id> Used as a proxy for making requests to pubmed
 @app.route("/pubmed/<id_>")
 @app.route("/pubmed/<id_>/")

--- a/tests/test_scicrunch.py
+++ b/tests/test_scicrunch.py
@@ -539,3 +539,14 @@ def test_dataset_citations_search(client):
     json_data = json.loads(data)
     assert 'id' in json_data
     assert json_data['id'] == identifier
+
+
+def test_scicrunch_resolver(client):
+    # Test the SciCrunch resolver proxy endpoint with RRID:SCR_018709
+    r = client.get('/scicrunch/resolver/RRID:SCR_018709')
+    assert r.status_code == 200
+    json_data = json.loads(r.data)
+    # The resolver response should contain resolver metadata and hits
+    assert 'resolver' in json_data
+    assert 'hits' in json_data
+    assert json_data['hits']['total'] > 0


### PR DESCRIPTION
# Description

This pull request introduces a new API proxy endpoint for the SciCrunch resolver and adds configuration and test coverage for it. This resolver is used to fetch data for expert consultants in map-sidebar connectivity.

This is a part of the sparc-app-issues/613.

**New SciCrunch Resolver Proxy:**

* Added a new configuration variable `SCI_CRUNCH_RESOLVER_HOST` to `Config` for specifying the SciCrunch resolver API base URL.
* Implemented the `/scicrunch/resolver/<rrid>` route in `app/main.py`, which proxies requests to the SciCrunch resolver API and handles errors gracefully.


## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

* Added `test_scicrunch_resolver` in `tests/test_scicrunch.py` to verify the resolver proxy endpoint returns expected metadata and hits for a given RRID.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added unit tests that prove my fix is effective or that my feature works

